### PR TITLE
Make run ordering deterministic (#2)

### DIFF
--- a/aidev.py
+++ b/aidev.py
@@ -153,8 +153,10 @@ Rules learned from user corrections will be appended here.
 
 
 def now_id() -> str:
-    stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
-    return f"{stamp}-{uuid.uuid4().hex[:6]}"
+    now = dt.datetime.now()
+    stamp = now.strftime("%Y%m%d-%H%M%S")
+    millis = f"{now.microsecond // 1000:03d}"
+    return f"{stamp}-{millis}-{uuid.uuid4().hex[:6]}"
 
 
 def read_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
@@ -1443,10 +1445,11 @@ def command_run(args: argparse.Namespace) -> int:
 
 def command_latest(_: argparse.Namespace) -> int:
     ensure_workspace()
-    runs = sorted([p for p in RUNS_DIR.iterdir() if p.is_dir()])
+    runs = [p for p in RUNS_DIR.iterdir() if p.is_dir()]
     if not runs:
         print("No runs yet.")
         return 0
+    runs.sort(key=lambda p: (p.stat().st_mtime_ns, p.name))
     latest = runs[-1]
     print(latest)
     audit = latest / "audit.json"

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -614,9 +614,10 @@ function hasGitRepository() {
 }
 
 function nowRunId(prefix = "") {
-  const iso = new Date().toISOString().replace(/[-:]/g, "").replace("T", "-");
+  const now = new Date();
+  const iso = now.toISOString().replace(/[-:]/g, "").replace("T", "-");
   const stamp = iso.slice(0, 15);
-  const millis = iso.slice(15, 18);
+  const millis = String(now.getMilliseconds()).padStart(3, "0");
   const suffix = crypto.randomBytes(3).toString("hex");
   return `${stamp}-${millis}-${prefix ? `${prefix}-` : ""}${suffix}`;
 }
@@ -991,9 +992,17 @@ function diagnosticsForSettings(merged) {
   };
 }
 
-function runSortTimestamp(dir, contract) {
+function runSortKeys(dir, contract) {
   const created = Date.parse(contract?.created_at || "");
+  let mtimeMs = 0;
+  try {
+    mtimeMs = fs.statSync(dir).mtimeMs;
+  } catch {}
   if (Number.isFinite(created)) return created;
+  return mtimeMs;
+}
+
+function runMtime(dir) {
   try {
     return fs.statSync(dir).mtimeMs;
   } catch {
@@ -1022,11 +1031,12 @@ function listRuns() {
         model: contract.model || "",
         usage,
         request: readText(path.join(dir, "request.md")).trim(),
-        sortKey: runSortTimestamp(dir, contract),
+        sortKey: runSortKeys(dir, contract),
+        mtimeMs: runMtime(dir),
       };
     })
-    .sort((a, b) => b.sortKey - a.sortKey || b.id.localeCompare(a.id))
-    .map(({ sortKey, ...rest }) => rest);
+    .sort((a, b) => b.sortKey - a.sortKey || b.mtimeMs - a.mtimeMs || b.id.localeCompare(a.id))
+    .map(({ sortKey, mtimeMs, ...rest }) => rest);
 }
 
 function readRun(runId) {

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -614,13 +614,11 @@ function hasGitRepository() {
 }
 
 function nowRunId(prefix = "") {
-  const stamp = new Date()
-    .toISOString()
-    .replace(/[-:]/g, "")
-    .replace("T", "-")
-    .slice(0, 15);
+  const iso = new Date().toISOString().replace(/[-:]/g, "").replace("T", "-");
+  const stamp = iso.slice(0, 15);
+  const millis = iso.slice(15, 18);
   const suffix = crypto.randomBytes(3).toString("hex");
-  return `${stamp}-${prefix ? `${prefix}-` : ""}${suffix}`;
+  return `${stamp}-${millis}-${prefix ? `${prefix}-` : ""}${suffix}`;
 }
 
 const SNAPSHOT_IGNORED_DIRS = new Set([".git", ".hg", ".svn", "node_modules", ".venv", "venv", "__pycache__", "dist", "build"]);
@@ -993,6 +991,16 @@ function diagnosticsForSettings(merged) {
   };
 }
 
+function runSortTimestamp(dir, contract) {
+  const created = Date.parse(contract?.created_at || "");
+  if (Number.isFinite(created)) return created;
+  try {
+    return fs.statSync(dir).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
 function listRuns() {
   const runsDir = projectRunsDir();
   if (!fs.existsSync(runsDir)) return [];
@@ -1014,9 +1022,11 @@ function listRuns() {
         model: contract.model || "",
         usage,
         request: readText(path.join(dir, "request.md")).trim(),
+        sortKey: runSortTimestamp(dir, contract),
       };
     })
-    .sort((a, b) => b.id.localeCompare(a.id));
+    .sort((a, b) => b.sortKey - a.sortKey || b.id.localeCompare(a.id))
+    .map(({ sortKey, ...rest }) => rest);
 }
 
 function readRun(runId) {

--- a/desktop/test/smoke.js
+++ b/desktop/test/smoke.js
@@ -44,6 +44,9 @@ assert.match(mainJs, /providerBaseUrl/, "provider-specific base URL routing is m
 assert.match(mainJs, /normalizeModelName/, "unsupported model aliases should be normalized");
 assert.doesNotMatch(mainJs, /model:\s*"gpt-5\.4-pro"|executor_max:\s*"gpt-5\.4-pro"/, "gpt-5.4-pro should not be a built-in/default model");
 assert.match(mainJs, /gpt-5\.5/, "gpt-5.5 should be available as the max model");
+assert.match(mainJs, /getMilliseconds\(\)\)\.padStart\(3,\s*"0"\)/, "JS run IDs should use three millisecond digits without slicing the ISO decimal point");
+assert.doesNotMatch(mainJs, /slice\(15,\s*18\)/, "JS run IDs should not derive milliseconds by slicing the ISO string");
+assert.match(mainJs, /b\.sortKey - a\.sortKey \|\| b\.mtimeMs - a\.mtimeMs \|\| b\.id\.localeCompare\(a\.id\)/, "desktop run sorting should use mtime before ID tie-breaker");
 
 assert.match(rendererJs, /runDiagnostics\(/, "renderer diagnostics action is missing");
 assert.match(rendererJs, /analyzing prompt\.\.\./, "send flow is missing analyzing step");

--- a/desktop/test/smoke.js
+++ b/desktop/test/smoke.js
@@ -195,9 +195,14 @@ assert.match(helloWorldPlan, /Task type: small_create/, "hello world should be a
 assert.match(helloWorldPlan, /Reasoning: none/, "hello world should use none reasoning");
 assert.match(helloWorldPlan, /Model: gpt-5\.4-mini/, "hello world should use the cheap mini model");
 
-const latestRun = fs.readdirSync(path.resolve(root, "..", ".ai", "runs")).sort().pop();
-const latestPrompt = fs.readFileSync(path.resolve(root, "..", ".ai", "runs", latestRun, "prompt.md"), "utf8");
-const latestUsage = JSON.parse(fs.readFileSync(path.resolve(root, "..", ".ai", "runs", latestRun, "usage.json"), "utf8"));
+const runsDir = path.resolve(root, "..", ".ai", "runs");
+const latestRun = fs.readdirSync(runsDir)
+  .map((name) => ({ name, mtimeMs: fs.statSync(path.join(runsDir, name)).mtimeMs }))
+  .sort((a, b) => a.mtimeMs - b.mtimeMs || a.name.localeCompare(b.name))
+  .pop().name;
+assert.match(latestRun, /^\d{8}-\d{6}-\d{3}-/, "run IDs should include millisecond precision");
+const latestPrompt = fs.readFileSync(path.resolve(runsDir, latestRun, "prompt.md"), "utf8");
+const latestUsage = JSON.parse(fs.readFileSync(path.resolve(runsDir, latestRun, "usage.json"), "utf8"));
 assert.ok(latestPrompt.length < 1900, "low task prompt should stay compact");
 assert.doesNotMatch(latestPrompt, /# Task Contract/, "low task prompt should not include full contract dump");
 assert.match(latestPrompt, /TASK/, "compact prompt should include task section");


### PR DESCRIPTION
## Summary
- Bump both run-ID generators (`aidev.py:now_id`, `desktop/src/main.js:nowRunId`) to millisecond precision: `YYYYMMDD-HHMMSS-fff[-prefix]-XXXXXX`. Backwards compatible with legacy IDs (same prefix, longer tail).
- Sort `listRuns()` by `contract.created_at` (parsed) with a directory `mtime` fallback, breaking ties by ID. Drops the lex-on-ID sort that misordered same-second runs.
- Sort `command_latest` in `aidev.py` by directory `mtime` so legacy runs without millisecond IDs still pick correctly.
- Update `desktop/test/smoke.js` to pick the latest run by `mtime` instead of `readdirSync().sort()`, and assert the new ID shape.

## Why
Run IDs included only second precision plus a random suffix, so multiple runs in the same second sorted by random text. `latest`, `state.runs[0]`, approval cards, direct result lookup, and the smoke test could all target the wrong run. Today's `.ai/runs/` already had three same-second collisions (`20260426-103831-{691b25,7d59a2,c3d7bd}`).

## Test plan
- [x] `cd desktop && npm run check` (Node syntax check on main/preload/renderer)
- [x] `cd desktop && npm run smoke` (passes; new ID-format assertion fires on the run produced by the test)
- [x] `python aidev.py latest` returns the most recent run (now uses mtime ordering)
- [x] New runs use ms-precision IDs (verified: `20260426-105123-395-5cfc2b`)

Closes #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)