### PR TITLE
Fix #7: stop misclassifying narrow errors as architecture/UI

### DIFF
--- a/aidev.py
+++ b/aidev.py
@@ -318,12 +318,19 @@ def classify_task(prompt: str, forced_reasoning: str | None = None) -> dict[str,
     has_security_risk = any(k in lower for k in ["security", "encrypted", "encryption", "payment"])
     has_migration_risk = any(k in lower for k in ["migration", "migrations", "миграц"])
     is_important = has_database_risk or has_auth_risk or has_security_risk or has_migration_risk
-    is_ui = any(k in lower for k in ["ui", "interface", "frontend", "css", "page", "dashboard", "visual", "button", "layout", "website", "client"])
+    ui_keywords = ["ui", "interface", "frontend", "css", "page", "dashboard", "visual", "button", "layout", "website"]
+    ui_phrase_patterns = [r"client[-\s]side", r"\bweb client\b", r"\bdesktop client\b", r"\bmobile client\b", r"\bbrowser client\b"]
+    is_ui = any(k in lower for k in ui_keywords) or any(re.search(p, lower) for p in ui_phrase_patterns)
     is_bug = any(k in lower for k in ["bug", "error", "fail", "fix", "traceback", "exception", "broken", "не работает", "ошибка"])
     is_easy_error = is_bug and any(k in lower for k in [
         "lint", "linter", "format", "formatter", "typo", "syntax", "semicolon", "import",
         "unused", "bracket", "quote", "прост", "легк", "линтер", "опечат", "скобк"
     ])
+    is_narrow_error = is_bug and bool(
+        re.search(r"\b(401|403|404|500|502|503|504)\b", lower)
+        or re.search(r"\b(invalid_client|invalid_grant|invalid_token|access[_\s-]?denied|access blocked|unauthorized|forbidden)\b", lower)
+        or re.search(r"\b(config|configuration|env|environment|credential|credentials|secret|token|key|api key)\b", lower)
+    )
     is_small_edit = (
         any(k in lower for k in ["change", "rename", "replace", "поменя", "измени", "замени", "переменн"])
         or has_word("set")
@@ -339,7 +346,10 @@ def classify_task(prompt: str, forced_reasoning: str | None = None) -> dict[str,
         "social platform", "архитектур", "база данных", "аутентификац", "авторизац"
     ])
     has_rewrite_keyword = has_word("rewrite") or "перепиш" in lower
-    is_arch = has_arch_keyword or is_important or (has_rewrite_keyword and len(words) > 14)
+    if is_narrow_error and not has_arch_keyword:
+        is_arch = False
+    else:
+        is_arch = has_arch_keyword or is_important or (has_rewrite_keyword and len(words) > 14)
     if is_arch:
         is_tiny_create = False
     is_create = any(k in lower for k in ["create", "build", "make", "code", "сделай", "создай", "напиши программу"])


### PR DESCRIPTION
## Summary
Two targeted changes to `classify_task` in `aidev.py` so narrow OAuth/config error reports stop being routed as architecture+UI work:

1. Replace the bare `client` UI keyword with phrase patterns (`client-side`, `web/desktop/mobile/browser client`) so OAuth client errors no longer flag `is_ui`.
2. Detect narrow error reports (HTTP status codes, auth error strings, config/credential terms in a bug context) and skip the `is_important`/rewrite-driven architecture promotion unless an explicit architecture keyword is present.

## Verification
- The OAuth fixture in `desktop/test/smoke.js` now classifies as `bugfix` with `Reasoning: medium` (was `architecture` + `is_ui=true`).
- UI builds, real architecture rewrites, and broad auth feature requests still classify as before.
- `cd desktop && npm run smoke` passes.

## Test plan
- [x] `cd desktop && npm run smoke`
- [x] OAuth fixture remains `Reasoning: medium`, never `high`

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)