### PR TITLE
Fix #1: detect drift before undoing a run

### DIFF
--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -3,6 +3,7 @@ const path = require("path");
 const fs = require("fs");
 const cp = require("child_process");
 const crypto = require("crypto");
+const { restoreRunFromDir } = require("./restore-run");
 
 const APP_ROOT = path.resolve(__dirname, "..", "..");
 const APP_AI_DIR = path.join(APP_ROOT, ".ai");
@@ -1109,64 +1110,11 @@ function runValidation(runId) {
 }
 
 function restoreRun(runId) {
-  const run = readRun(runId);
-  if (!run) {
-    return { ok: false, error: "Run not found." };
-  }
-  const before = readJson(path.join(run.path, "before-state.json"), {});
-  const beforeFiles = before.files || {};
-  const backupDir = path.join(run.path, "before-files");
-  const afterFiles = snapshot_files_safe();
-  const changed = new Set([
-    ...Object.keys(beforeFiles),
-    ...Object.keys(afterFiles),
-  ].filter((name) => beforeFiles[name] !== afterFiles[name]));
-  const files = Array.from(changed);
-  if (!files.length) {
-    return { ok: true, restored: [], removed: [] };
-  }
-  const gitFallback = [];
-  const removed = [];
-  const restored = [];
-  for (const rel of files) {
-    const abs = path.join(projectRoot(), rel);
-    const existedBefore = Object.prototype.hasOwnProperty.call(beforeFiles, rel);
-    if (!existedBefore) {
-      if (!fs.existsSync(abs)) continue;
-      removed.push(rel);
-      try {
-        fs.rmSync(abs, { force: true });
-      } catch {}
-      continue;
-    }
-    const backup = path.join(backupDir, rel);
-    if (fs.existsSync(backup)) {
-      ensureDir(path.dirname(abs));
-      fs.copyFileSync(backup, abs);
-      restored.push(rel);
-      continue;
-    }
-    gitFallback.push(rel);
-  }
-  if (gitFallback.length) {
-    const git = resolveCommand("git");
-    if (!git || !hasGitRepository()) {
-      return {
-        ok: false,
-        error: "Undo needs this run's local backup snapshot or a git repository. Re-run the task once with the updated app to get backup-based undo.",
-      };
-    }
-    const result = cp.spawnSync(git, ["restore", "--source=HEAD", "--worktree", "--staged", "--", ...gitFallback], {
-      cwd: projectRoot(),
-      shell: needsShell(git),
-      windowsHide: true,
-      encoding: "utf8",
-    });
-    if (result.status !== 0) {
-      return { ok: false, error: result.stderr || result.stdout || "Undo failed." };
-    }
-  }
-  return { ok: true, restored: [...restored, ...gitFallback], removed };
+  const runDir = path.join(projectRunsDir(), String(runId));
+  return restoreRunFromDir(runDir, projectRoot(), {
+    resolveGit: () => resolveCommand("git"),
+    hasGitRepository: () => hasGitRepository(),
+  });
 }
 
 function snapshot_files_safe() {

--- a/desktop/src/restore-run.js
+++ b/desktop/src/restore-run.js
@@ -95,6 +95,17 @@ function restoreRunFromDir(runDir, root, options = {}) {
       drifted: drifted.sort(),
     };
   }
+  let git = null;
+  if (safeForGitFallback.length) {
+    git = options.resolveGit ? options.resolveGit() : null;
+    const haveGit = options.hasGitRepository ? options.hasGitRepository() : false;
+    if (!git || !haveGit) {
+      return {
+        ok: false,
+        error: "Undo needs this run's local backup snapshot or a git repository. Re-run the task once with the updated app to get backup-based undo.",
+      };
+    }
+  }
   const removed = [];
   const restored = [];
   for (const rel of safeForRemoval) {
@@ -113,14 +124,6 @@ function restoreRunFromDir(runDir, root, options = {}) {
     restored.push(rel);
   }
   if (safeForGitFallback.length) {
-    const git = options.resolveGit ? options.resolveGit() : null;
-    const haveGit = options.hasGitRepository ? options.hasGitRepository() : false;
-    if (!git || !haveGit) {
-      return {
-        ok: false,
-        error: "Undo needs this run's local backup snapshot or a git repository. Re-run the task once with the updated app to get backup-based undo.",
-      };
-    }
     const result = cp.spawnSync(git, ["restore", "--source=HEAD", "--worktree", "--staged", "--", ...safeForGitFallback], {
       cwd: root,
       shell: needsShell(git),

--- a/desktop/src/restore-run.js
+++ b/desktop/src/restore-run.js
@@ -1,0 +1,142 @@
+const fs = require("fs");
+const path = require("path");
+const cp = require("child_process");
+const crypto = require("crypto");
+
+function readJson(file, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function fileHash(file) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(file));
+  return hash.digest("hex");
+}
+
+function fileHashOrNull(abs) {
+  try {
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) return null;
+    return fileHash(abs);
+  } catch {
+    return null;
+  }
+}
+
+function needsShell(command) {
+  return process.platform === "win32" && /\.(cmd|bat)$/i.test(String(command || ""));
+}
+
+function restoreRunFromDir(runDir, root, options = {}) {
+  if (!fs.existsSync(runDir)) {
+    return { ok: false, error: "Run not found." };
+  }
+  const before = readJson(path.join(runDir, "before-state.json"), {});
+  const after = readJson(path.join(runDir, "after-state.json"), {});
+  const beforeFiles = before.files || {};
+  const afterFiles = after.files;
+  if (!afterFiles || typeof afterFiles !== "object") {
+    return {
+      ok: false,
+      error: "Undo unavailable: this run does not have an after-state file map. Re-run the task on the updated app to enable drift-protected undo.",
+    };
+  }
+  const backupDir = path.join(runDir, "before-files");
+  const tracked = Array.from(new Set([
+    ...Object.keys(beforeFiles),
+    ...Object.keys(afterFiles),
+  ])).filter((name) => beforeFiles[name] !== afterFiles[name]);
+  if (!tracked.length) {
+    return { ok: true, restored: [], removed: [], drifted: [] };
+  }
+  const drifted = [];
+  const safeForBackupRestore = [];
+  const safeForRemoval = [];
+  const safeForGitFallback = [];
+  for (const rel of tracked) {
+    const abs = path.join(root, rel);
+    const recordedAfter = afterFiles[rel];
+    const currentHash = fileHashOrNull(abs);
+    const hadAfter = Object.prototype.hasOwnProperty.call(afterFiles, rel);
+    const hadBefore = Object.prototype.hasOwnProperty.call(beforeFiles, rel);
+    if (hadAfter && recordedAfter) {
+      if (currentHash !== recordedAfter) {
+        drifted.push(rel);
+        continue;
+      }
+    } else {
+      if (currentHash !== null) {
+        drifted.push(rel);
+        continue;
+      }
+    }
+    if (!hadBefore) {
+      safeForRemoval.push(rel);
+      continue;
+    }
+    const backup = path.join(backupDir, rel);
+    if (fs.existsSync(backup)) {
+      safeForBackupRestore.push(rel);
+    } else {
+      safeForGitFallback.push(rel);
+    }
+  }
+  if (drifted.length) {
+    return {
+      ok: false,
+      error: `Undo refused: ${drifted.length} file(s) have changed since this run finished. Review and revert manually if needed.`,
+      drifted: drifted.sort(),
+    };
+  }
+  const removed = [];
+  const restored = [];
+  for (const rel of safeForRemoval) {
+    const abs = path.join(root, rel);
+    if (!fs.existsSync(abs)) continue;
+    try {
+      fs.rmSync(abs, { force: true });
+      removed.push(rel);
+    } catch {}
+  }
+  for (const rel of safeForBackupRestore) {
+    const abs = path.join(root, rel);
+    const backup = path.join(backupDir, rel);
+    ensureDir(path.dirname(abs));
+    fs.copyFileSync(backup, abs);
+    restored.push(rel);
+  }
+  if (safeForGitFallback.length) {
+    const git = options.resolveGit ? options.resolveGit() : null;
+    const haveGit = options.hasGitRepository ? options.hasGitRepository() : false;
+    if (!git || !haveGit) {
+      return {
+        ok: false,
+        error: "Undo needs this run's local backup snapshot or a git repository. Re-run the task once with the updated app to get backup-based undo.",
+      };
+    }
+    const result = cp.spawnSync(git, ["restore", "--source=HEAD", "--worktree", "--staged", "--", ...safeForGitFallback], {
+      cwd: root,
+      shell: needsShell(git),
+      windowsHide: true,
+      encoding: "utf8",
+    });
+    if (result.status !== 0) {
+      return { ok: false, error: result.stderr || result.stdout || "Undo failed." };
+    }
+  }
+  return {
+    ok: true,
+    restored: [...restored, ...safeForGitFallback],
+    removed,
+    drifted: [],
+  };
+}
+
+module.exports = { restoreRunFromDir, fileHashOrNull };

--- a/desktop/test/restore-run.test.js
+++ b/desktop/test/restore-run.test.js
@@ -154,6 +154,30 @@ test("drift: detects when user re-creates a file the run never produced", () => 
   assert.equal(fs.readFileSync(path.join(root, "deleted.txt"), "utf8"), "user re-created\n");
 });
 
+test("fallback preflight: missing git aborts before removing run-created files", () => {
+  const { root, runDir } = makeWorld();
+  const original = Buffer.from("original without backup\n");
+  const runChanged = Buffer.from("changed by run\n");
+  const created = Buffer.from("created by run\n");
+  writeFile(root, "fallback.txt", runChanged);
+  writeFile(root, "created.txt", created);
+  recordStates(
+    runDir,
+    { "fallback.txt": sha256(original) },
+    { "fallback.txt": sha256(runChanged), "created.txt": sha256(created) },
+  );
+
+  const result = restoreRunFromDir(runDir, root, {
+    resolveGit: () => null,
+    hasGitRepository: () => false,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /backup snapshot or a git repository/);
+  assert.equal(fs.readFileSync(path.join(root, "created.txt"), "utf8"), "created by run\n", "run-created file must not be removed after preflight failure");
+  assert.equal(fs.readFileSync(path.join(root, "fallback.txt"), "utf8"), "changed by run\n", "fallback file must not be changed after preflight failure");
+});
+
 test("legacy run without after-state files map: refuses undo (does not delete anything)", () => {
   const { root, runDir } = makeWorld();
   const created = Buffer.from("from run\n");

--- a/desktop/test/restore-run.test.js
+++ b/desktop/test/restore-run.test.js
@@ -1,0 +1,196 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const crypto = require("node:crypto");
+const assert = require("node:assert/strict");
+
+const { restoreRunFromDir } = require("../src/restore-run");
+
+function sha256(buf) {
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+function makeWorld() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aidev-restore-"));
+  const runDir = path.join(root, ".ai", "runs", "20260101-000000-000-test");
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.mkdirSync(path.join(runDir, "before-files"), { recursive: true });
+  return { root, runDir };
+}
+
+function writeFile(root, rel, contents) {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents);
+}
+
+function backupFile(runDir, rel, contents) {
+  const abs = path.join(runDir, "before-files", rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents);
+}
+
+function recordStates(runDir, before, after) {
+  fs.writeFileSync(
+    path.join(runDir, "before-state.json"),
+    JSON.stringify({ git: { has_git: false }, files: before }),
+  );
+  fs.writeFileSync(
+    path.join(runDir, "after-state.json"),
+    JSON.stringify({ git: { has_git: false }, files: after }),
+  );
+}
+
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`  FAIL  ${name}`);
+    console.error(err);
+  }
+}
+
+console.log("restoreRunFromDir:");
+
+test("happy path: reverts run-modified file when current hash still matches after-state", () => {
+  const { root, runDir } = makeWorld();
+  const original = Buffer.from("original\n");
+  const runChanged = Buffer.from("run wrote this\n");
+  backupFile(runDir, "src/foo.txt", original);
+  writeFile(root, "src/foo.txt", runChanged);
+  recordStates(runDir, { "src/foo.txt": sha256(original) }, { "src/foo.txt": sha256(runChanged) });
+
+  const result = restoreRunFromDir(runDir, root);
+
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.deepEqual(result.restored, ["src/foo.txt"]);
+  assert.equal(fs.readFileSync(path.join(root, "src/foo.txt"), "utf8"), "original\n");
+});
+
+test("happy path: removes file the run created when nothing else has touched it", () => {
+  const { root, runDir } = makeWorld();
+  const created = Buffer.from("new file\n");
+  writeFile(root, "src/new.txt", created);
+  recordStates(runDir, {}, { "src/new.txt": sha256(created) });
+
+  const result = restoreRunFromDir(runDir, root);
+
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.deepEqual(result.removed, ["src/new.txt"]);
+  assert.equal(fs.existsSync(path.join(root, "src/new.txt")), false);
+});
+
+test("drift: refuses to delete a file the user has edited after the run", () => {
+  const { root, runDir } = makeWorld();
+  const runWrote = Buffer.from("run wrote\n");
+  const userEdited = Buffer.from("user edited later\n");
+  writeFile(root, "src/created.txt", userEdited);
+  recordStates(runDir, {}, { "src/created.txt": sha256(runWrote) });
+
+  const result = restoreRunFromDir(runDir, root);
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.drifted, ["src/created.txt"]);
+  assert.equal(fs.readFileSync(path.join(root, "src/created.txt"), "utf8"), "user edited later\n", "user edit must be preserved");
+});
+
+test("drift: refuses to overwrite a file the user has further edited after the run", () => {
+  const { root, runDir } = makeWorld();
+  const original = Buffer.from("v0\n");
+  const runWrote = Buffer.from("v1 from run\n");
+  const userLater = Buffer.from("v2 user edit\n");
+  backupFile(runDir, "src/code.js", original);
+  writeFile(root, "src/code.js", userLater);
+  recordStates(runDir, { "src/code.js": sha256(original) }, { "src/code.js": sha256(runWrote) });
+
+  const result = restoreRunFromDir(runDir, root);
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.drifted, ["src/code.js"]);
+  assert.equal(fs.readFileSync(path.join(root, "src/code.js"), "utf8"), "v2 user edit\n", "user edit must be preserved");
+});
+
+test("drift: any tracked drift aborts the whole undo (no partial revert)", () => {
+  const { root, runDir } = makeWorld();
+  const aOriginal = Buffer.from("a0\n");
+  const aRun = Buffer.from("a1\n");
+  const bRun = Buffer.from("b1\n");
+  const bUser = Buffer.from("b2 user\n");
+  backupFile(runDir, "a.txt", aOriginal);
+  writeFile(root, "a.txt", aRun);
+  writeFile(root, "b.txt", bUser);
+  recordStates(
+    runDir,
+    { "a.txt": sha256(aOriginal) },
+    { "a.txt": sha256(aRun), "b.txt": sha256(bRun) },
+  );
+
+  const result = restoreRunFromDir(runDir, root);
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.drifted, ["b.txt"]);
+  assert.equal(fs.readFileSync(path.join(root, "a.txt"), "utf8"), "a1\n", "a.txt must NOT have been reverted because the whole undo aborted");
+  assert.equal(fs.readFileSync(path.join(root, "b.txt"), "utf8"), "b2 user\n");
+});
+
+test("drift: detects when user re-creates a file the run never produced", () => {
+  const { root, runDir } = makeWorld();
+  const original = Buffer.from("v0\n");
+  backupFile(runDir, "deleted.txt", original);
+  writeFile(root, "deleted.txt", Buffer.from("user re-created\n"));
+  recordStates(
+    runDir,
+    { "deleted.txt": sha256(original) },
+    {},
+  );
+
+  const result = restoreRunFromDir(runDir, root);
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.drifted, ["deleted.txt"]);
+  assert.equal(fs.readFileSync(path.join(root, "deleted.txt"), "utf8"), "user re-created\n");
+});
+
+test("legacy run without after-state files map: refuses undo (does not delete anything)", () => {
+  const { root, runDir } = makeWorld();
+  const created = Buffer.from("from run\n");
+  writeFile(root, "src/created.txt", created);
+  fs.writeFileSync(
+    path.join(runDir, "before-state.json"),
+    JSON.stringify({ git: { has_git: false }, files: {} }),
+  );
+  fs.writeFileSync(
+    path.join(runDir, "after-state.json"),
+    JSON.stringify({ git: { has_git: false } }),
+  );
+
+  const result = restoreRunFromDir(runDir, root);
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /after-state file map/);
+  assert.equal(fs.existsSync(path.join(root, "src/created.txt")), true, "file must NOT be deleted when after-state is incomplete");
+});
+
+test("missing run dir reports run not found", () => {
+  const result = restoreRunFromDir(path.join(os.tmpdir(), "does-not-exist-" + Date.now()), os.tmpdir());
+  assert.equal(result.ok, false);
+  assert.match(result.error, /Run not found/);
+});
+
+test("no tracked changes reports an empty success", () => {
+  const { root, runDir } = makeWorld();
+  recordStates(runDir, {}, {});
+  const result = restoreRunFromDir(runDir, root);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.restored, []);
+  assert.deepEqual(result.removed, []);
+});
+
+if (failed) {
+  console.error(`\n${failed} test(s) failed.`);
+  process.exit(1);
+}
+console.log("\nAll restore-run tests passed.");

--- a/desktop/test/smoke.js
+++ b/desktop/test/smoke.js
@@ -215,4 +215,6 @@ assert.ok(latestUsage.tokens.total > 0, "usage should record token estimate");
 assert.ok(latestUsage.context.used_percent >= 0, "usage should record context fill");
 assert.ok(latestUsage.cost.estimated_usd >= 0, "usage should record cost estimate");
 
+cp.execFileSync(process.execPath, [path.resolve(__dirname, "restore-run.test.js")], { stdio: "inherit" });
+
 console.log("Smoke checks passed.");


### PR DESCRIPTION
## Summary
- Replaces the workspace-vs-before-snapshot diff in `restoreRun` with a hash-based drift check against the run's recorded after-state.
- Before any deletion or overwrite, every tracked file's current hash is compared with `after-state.json.files[rel]`. Any drift aborts the entire undo (no partial revert) and surfaces the drifted paths in `result.drifted`.
- Files whose current hash still matches the after-snapshot are reverted from `before-files/` (or via `git restore` fallback when no backup exists).
- Runs without an after-state files map (legacy runs and current supervisor-mode runs from `aidev.py`, which only records `git` in `after-state.json`) refuse undo with an explanatory message instead of deleting based on stale data.
- Restore logic was extracted into `desktop/src/restore-run.js` so it is unit-testable without booting Electron. The previous `restoreRun` is now a thin wrapper that resolves project paths and `git` lookup at call time.

## Test plan
- [x] `cd desktop && npm run check`
- [x] `cd desktop && npm run smoke` (now runs the new restore-run unit tests too)
- [x] New tests in `desktop/test/restore-run.test.js` cover:
  - happy path: revert a run-modified file when its current hash still matches the after-snapshot
  - happy path: remove a file the run created when nothing else has touched it
  - drift: refuses to delete a file the user has edited after the run (the regression from #1)
  - drift: refuses to overwrite a file the user has further edited after the run
  - drift: any tracked drift aborts the whole undo (no partial revert)
  - drift: detects when the user re-creates a file the run had deleted
  - legacy run without after-state files map: refuses undo (does not delete anything)
  - missing run dir reports run not found
  - no tracked changes returns an empty success
- [ ] Manual: in the desktop app, run a small direct task, edit one of the changed files yourself, then click Undo — confirm the operation is refused and your edits remain.

## Follow-up
Supervisor-mode runs go through `aidev.py`, which currently writes `after-state.json` with only the `git` block. Once that file also includes a `files` hash map (matches direct mode), supervisor runs will be drift-checkable too. Coordinating with the backend lane separately.

Closes #1