### PR TITLE
Add file hash snapshot to supervisor after-state.json (#1)

### DIFF
--- a/aidev.py
+++ b/aidev.py
@@ -1420,7 +1420,8 @@ def command_run(args: argparse.Namespace) -> int:
     if codex_result.get("duration_seconds") is not None:
         phase_seconds["codex_exec"] = float(codex_result["duration_seconds"])
     after_git = measure_phase("git_after", get_git_state)
-    write_json(run_dir / "after-state.json", {"git": after_git})
+    after_snapshot = measure_phase("snapshot_after", snapshot_files)
+    write_json(run_dir / "after-state.json", {"git": after_git, "files": after_snapshot})
     if after_git.get("diff"):
         (run_dir / "after-diff.patch").write_text(str(after_git["diff"]), encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Backend follow-up for #1 / PR #21 (electron's undo drift detection).
- Direct-mode runs already write `{git, files}` to `after-state.json` (desktop/src/main.js:1554), but the supervisor path in `aidev.py` only wrote `{git}`. PR #21 hashes tracked files against the after-state `files` map and refuses undo when the map is missing, which left supervisor-mode runs un-undoable.
- This adds a `snapshot_after` measurement parallel to the existing `snapshot_before`, and includes its result as `files` in the after-state write. `before_snapshot` is preserved as the input to `changed_files()` so audit/diff behavior is unchanged.
- Strictly additive: lands before or after #21 in either order. Once both are merged, supervisor-mode undo becomes drift-checkable; until then #21's safe default still applies.

Refs #1

## Test plan
- [x] `python aidev.py "x" --ui-settings "{}"` — planning-mode invocation completes without errors (sanity check on imports/syntax).
- [x] `cd desktop && npm run smoke` — `Smoke checks passed.`
- [ ] After merge with PR #21: a supervisor-mode `--execute` run produces an `after-state.json` containing `files`, and `electron`'s undo drift-check accepts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)