### PR TITLE
Add pytest unit tests for aidev.py (close #11)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+addopts = -ra --strict-markers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+os.environ.setdefault("AIDEV_PROJECT_ROOT", str(REPO_ROOT))
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_build_codex_prompt.py
+++ b/tests/test_build_codex_prompt.py
@@ -1,0 +1,180 @@
+"""Unit tests for aidev.build_codex_prompt prompt assembly.
+
+Note: at lower reasoning tiers, `tier_limits` caps the assembled prompt
+aggressively (1400 chars at `none`, 1800 at `low`). The boilerplate added by
+`build_enhanced_prompt` / `build_technical_prompt` already exceeds those
+budgets, so trailing sections (SCOPE, FINAL RESPONSE, etc.) get truncated by
+the outer `trim_chars`. The tests below assert that contract: required
+front-of-prompt sections always survive, and optional later sections appear
+only at higher reasoning tiers where there is headroom.
+"""
+
+import json
+
+import pytest
+
+from aidev import (
+    DEFAULT_RULES,
+    build_codex_prompt,
+    build_contract,
+    classify_task,
+    tier_limits,
+)
+
+
+def _budget_status() -> dict:
+    return {
+        "decision": "ok",
+        "reason": "",
+        "request_estimate_usd": 0.05,
+        "request_budget_usd": 0.5,
+        "request_percent": 10.0,
+    }
+
+
+def _make_contract(prompt: str, *, forced_reasoning=None, feature_flags=None):
+    classification = classify_task(prompt, forced_reasoning=forced_reasoning)
+    return build_contract(
+        prompt=prompt,
+        classification=classification,
+        model="gpt-5.4-mini",
+        budget_status=_budget_status(),
+        feature_flags=feature_flags,
+        supervisor={"model": "gpt-5.4-mini", "reasoning": "low"},
+    )
+
+
+# Sections that fit within the budget at every reasoning tier.
+ALWAYS_PRESENT_SECTIONS = (
+    "You are Codex executing one supervised local task.",
+    "TASK",
+    "SETTINGS",
+    "RULES",
+)
+
+
+@pytest.mark.parametrize("reasoning", ["none", "low", "medium", "high", "xhigh"])
+def test_prompt_contains_front_sections_for_each_reasoning(reasoning):
+    contract = _make_contract("do something", forced_reasoning=reasoning)
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    for section in ALWAYS_PRESENT_SECTIONS:
+        assert section in prompt, f"missing {section!r} for reasoning={reasoning}"
+
+
+@pytest.mark.parametrize("reasoning", ["none", "low", "medium", "high", "xhigh"])
+def test_prompt_respects_tier_limit(reasoning):
+    contract = _make_contract("do something", forced_reasoning=reasoning)
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    limit = tier_limits(reasoning)["prompt"]
+    assert len(prompt) <= limit, (
+        f"prompt length {len(prompt)} exceeds tier limit {limit} for {reasoning}"
+    )
+
+
+@pytest.mark.parametrize("reasoning", ["high", "xhigh"])
+def test_prompt_contains_final_response_at_high_tiers(reasoning):
+    """At high/xhigh tiers there is enough budget for FINAL RESPONSE to survive."""
+    contract = _make_contract("do something", forced_reasoning=reasoning)
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    assert "FINAL RESPONSE" in prompt
+    assert "TECHNICAL PROMPT" in prompt
+
+
+def test_high_reasoning_includes_scope_with_rollback_section():
+    contract = _make_contract("do something", forced_reasoning="high")
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    assert "SCOPE" in prompt
+    assert "Allowed:" in prompt
+    assert "Forbidden:" in prompt
+    assert "Rollback required if:" in prompt
+
+
+def test_high_reasoning_includes_contract_summary_json():
+    contract = _make_contract("do something", forced_reasoning="high")
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    assert "CONTRACT SUMMARY" in prompt
+    summary_index = prompt.index("CONTRACT SUMMARY")
+    json_start = prompt.index("{", summary_index)
+    # Find the matching closing brace by walking depth.
+    depth = 0
+    json_end = json_start
+    for i in range(json_start, len(prompt)):
+        ch = prompt[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                json_end = i + 1
+                break
+    parsed = json.loads(prompt[json_start:json_end])
+    assert parsed["model"] == "gpt-5.4-mini"
+    assert parsed["classification"]["reasoning"] == "high"
+
+
+def test_xhigh_reasoning_includes_contract_summary():
+    contract = _make_contract("do something", forced_reasoning="xhigh")
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    assert "CONTRACT SUMMARY" in prompt
+
+
+def test_low_reasoning_omits_contract_summary():
+    contract = _make_contract("rename helper to compute_total")
+    assert contract["classification"]["reasoning"] in {"none", "low"}
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    assert "CONTRACT SUMMARY" not in prompt
+
+
+def test_medium_reasoning_omits_contract_summary():
+    contract = _make_contract("do something", forced_reasoning="medium")
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    assert "CONTRACT SUMMARY" not in prompt
+
+
+def test_todolist_feature_at_high_adds_todo_stage_contract_section():
+    """TODO STAGE CONTRACT only fits within the prompt budget at high+ tiers."""
+    contract = _make_contract(
+        "add staged feature work",
+        forced_reasoning="high",
+        feature_flags={"request_feature": "todolist"},
+    )
+    assert contract["stage_policy"]["requires_todo_stages"] is True
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    assert "TODO STAGE CONTRACT" in prompt
+    assert "Start by writing the staged TODO list" in prompt
+
+
+def test_non_todolist_feature_omits_todo_stage_contract_section():
+    contract = _make_contract("do something", forced_reasoning="high")
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    assert "TODO STAGE CONTRACT" not in prompt
+
+
+def test_prompt_includes_user_request_text():
+    contract = _make_contract("do something distinctive_xyz")
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    # The enhanced prompt is built around the original user request, so the
+    # distinctive marker word must appear somewhere in the assembled output.
+    assert "distinctive_xyz" in prompt
+
+
+def test_prompt_includes_model_in_settings_block():
+    contract = _make_contract("do something")
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    assert "gpt-5.4-mini" in prompt
+
+
+def test_tier_limits_for_each_reasoning_level():
+    levels = ["none", "low", "medium", "high", "xhigh"]
+    limits = [tier_limits(level)["prompt"] for level in levels]
+    # Limits must be strictly non-decreasing as reasoning grows.
+    assert limits == sorted(limits)
+    # Unknown reasoning falls back to the medium tier limits.
+    assert tier_limits("bogus") == tier_limits("medium")
+
+
+def test_unknown_tier_uses_medium_prompt_limit():
+    contract = _make_contract("do something", forced_reasoning="medium")
+    contract["classification"]["reasoning"] = "bogus"
+    prompt = build_codex_prompt(contract, DEFAULT_RULES)
+    assert len(prompt) <= tier_limits("medium")["prompt"]

--- a/tests/test_choose_model.py
+++ b/tests/test_choose_model.py
@@ -1,0 +1,186 @@
+"""Unit tests for aidev.choose_model and normalize_model_name."""
+
+import pytest
+
+from aidev import DEFAULT_CONFIG, choose_model, normalize_model_name
+
+
+def _classification(reasoning: str = "low", task_type: str = "general") -> dict:
+    return {
+        "task_type": task_type,
+        "complexity": reasoning if reasoning != "xhigh" else "extra_high",
+        "reasoning": reasoning,
+        "risk": "low",
+        "needs_plan": False,
+        "is_ui": False,
+        "is_tiny_create": False,
+        "requires_approval": reasoning in {"high", "xhigh"},
+    }
+
+
+def test_normalize_model_name_aliases_pro_to_55():
+    assert normalize_model_name("gpt-5.4-pro") == "gpt-5.5"
+
+
+def test_normalize_model_name_passthrough():
+    assert normalize_model_name("gpt-5.4") == "gpt-5.4"
+    assert normalize_model_name("gpt-5.4-mini") == "gpt-5.4-mini"
+
+
+def test_normalize_model_name_strips_whitespace():
+    assert normalize_model_name("  gpt-5.4-mini  ") == "gpt-5.4-mini"
+
+
+def test_normalize_model_name_handles_empty():
+    assert normalize_model_name("") == ""
+    assert normalize_model_name(None) == ""  # type: ignore[arg-type]
+
+
+def test_choose_model_forced_overrides_everything():
+    chosen = choose_model(
+        DEFAULT_CONFIG,
+        _classification("xhigh"),
+        forced_model="gpt-5.4-pro",
+    )
+    assert chosen == "gpt-5.5"  # alias normalized
+
+
+def test_choose_model_xhigh_picks_executor_max():
+    chosen = choose_model(DEFAULT_CONFIG, _classification("xhigh"))
+    assert chosen == DEFAULT_CONFIG["models"]["executor_max"]
+
+
+def test_choose_model_high_picks_executor_complex():
+    chosen = choose_model(DEFAULT_CONFIG, _classification("high"))
+    assert chosen == DEFAULT_CONFIG["models"]["executor_complex"]
+
+
+def test_choose_model_medium_picks_executor_complex():
+    chosen = choose_model(DEFAULT_CONFIG, _classification("medium"))
+    assert chosen == DEFAULT_CONFIG["models"]["executor_complex"]
+
+
+@pytest.mark.parametrize("reasoning", ["none", "low"])
+def test_choose_model_low_reasoning_picks_default(reasoning):
+    chosen = choose_model(DEFAULT_CONFIG, _classification(reasoning))
+    assert chosen == DEFAULT_CONFIG["models"]["executor_default"]
+
+
+def test_choose_model_manual_mode_uses_manual_model():
+    ui_settings = {
+        "supervisor_model_mode": "manual",
+        "supervisor_manual_model": "gpt-5.4-pro",
+    }
+    chosen = choose_model(
+        DEFAULT_CONFIG,
+        _classification("low"),
+        ui_settings=ui_settings,
+    )
+    # Manual model also flows through normalize_model_name.
+    assert chosen == "gpt-5.5"
+
+
+def test_choose_model_manual_mode_without_manual_model_falls_back_to_auto():
+    ui_settings = {
+        "supervisor_model_mode": "manual",
+        "supervisor_manual_model": "",
+    }
+    chosen = choose_model(
+        DEFAULT_CONFIG,
+        _classification("low"),
+        ui_settings=ui_settings,
+    )
+    # No manual model, no `task` mode, no catalog -> auto picks executor_default.
+    assert chosen == DEFAULT_CONFIG["models"]["executor_default"]
+
+
+def test_choose_model_task_mode_matches_task_tag():
+    config = {
+        **DEFAULT_CONFIG,
+        "models": {
+            **DEFAULT_CONFIG["models"],
+            "catalog": [
+                {
+                    "model": "specialist-bug-model",
+                    "mode": "both",
+                    "enabled": True,
+                    "task_tags": "bugfix",
+                },
+                {
+                    "model": "fallback-model",
+                    "mode": "both",
+                    "enabled": True,
+                    "task_tags": "*",
+                },
+            ],
+        },
+    }
+    ui_settings = {"supervisor_model_mode": "task"}
+    chosen = choose_model(
+        config,
+        _classification("low", task_type="bugfix"),
+        ui_settings=ui_settings,
+    )
+    assert chosen == "specialist-bug-model"
+
+
+def test_choose_model_task_mode_falls_back_to_wildcard_entry():
+    config = {
+        **DEFAULT_CONFIG,
+        "models": {
+            **DEFAULT_CONFIG["models"],
+            "catalog": [
+                {
+                    "model": "specialist-only-for-ui",
+                    "mode": "both",
+                    "enabled": True,
+                    "task_tags": "ui",
+                },
+                {
+                    "model": "any-fallback",
+                    "mode": "both",
+                    "enabled": True,
+                    "task_tags": "any",
+                },
+            ],
+        },
+    }
+    ui_settings = {"supervisor_model_mode": "task"}
+    chosen = choose_model(
+        config,
+        _classification("low", task_type="bugfix"),
+        ui_settings=ui_settings,
+    )
+    assert chosen == "any-fallback"
+
+
+def test_choose_model_task_mode_skips_disabled_entries():
+    config = {
+        **DEFAULT_CONFIG,
+        "models": {
+            **DEFAULT_CONFIG["models"],
+            "catalog": [
+                {
+                    "model": "disabled-bug-model",
+                    "mode": "both",
+                    "enabled": False,
+                    "task_tags": "bugfix",
+                },
+            ],
+        },
+    }
+    ui_settings = {"supervisor_model_mode": "task"}
+    chosen = choose_model(
+        config,
+        _classification("low", task_type="bugfix"),
+        ui_settings=ui_settings,
+    )
+    # Disabled entry skipped, no other catalog entries, no supervisor_model in
+    # ui_settings -> auto path picks executor_default.
+    assert chosen == DEFAULT_CONFIG["models"]["executor_default"]
+
+
+def test_choose_model_handles_missing_executor_keys_with_defaults():
+    config = {"models": {}}  # nothing configured
+    chosen = choose_model(config, _classification("xhigh"))
+    assert chosen == "gpt-5.5"  # the literal default in choose_model

--- a/tests/test_classify_task.py
+++ b/tests/test_classify_task.py
@@ -1,0 +1,165 @@
+"""Unit tests for aidev.classify_task.
+
+Covers the rules captured in `.ai/rules/reasoning.md` and the regression cases
+from issue #7 (narrow auth/OAuth errors must not get pulled up to architecture).
+"""
+
+import pytest
+
+from aidev import classify_task
+
+
+def test_typo_error_is_none_reasoning():
+    result = classify_task("fix typo in README")
+    assert result["reasoning"] == "none"
+    assert result["task_type"] == "bugfix"
+    assert result["requires_approval"] is False
+    assert result["risk"] == "low"
+
+
+def test_linter_error_is_none_reasoning():
+    result = classify_task("fix linter error in app.py")
+    assert result["reasoning"] == "none"
+    assert result["task_type"] == "bugfix"
+
+
+def test_small_rename_is_none():
+    result = classify_task("rename helper to compute_total")
+    assert result["reasoning"] == "none"
+    assert result["task_type"] == "small_edit"
+
+
+def test_tiny_create_is_none_reasoning():
+    result = classify_task("write hello world script")
+    assert result["reasoning"] == "none"
+    assert result["task_type"] == "small_create"
+    assert result["is_tiny_create"] is True
+
+
+def test_plain_bug_falls_to_low():
+    # Avoid UI keywords (page, button, dashboard, ...) so this stays a bugfix.
+    # Includes a bug marker (`error`) without easy-error markers and without
+    # small_edit verbs, so it should land on the bug branch with `low` reasoning.
+    result = classify_task("we get a runtime error on startup, please investigate why")
+    assert result["task_type"] == "bugfix"
+    assert result["reasoning"] == "low"
+
+
+def test_ui_request_classified_as_ui_with_low_or_medium_reasoning():
+    result = classify_task("tweak the dashboard button color")
+    assert result["is_ui"] is True
+    assert result["task_type"] == "ui"
+    assert result["reasoning"] in {"low", "medium"}
+    assert result["needs_plan"] is True
+
+
+def test_narrow_oauth_fix_is_medium_not_high():
+    """Regression for #7: narrow OAuth/auth fixes must not get pulled to high.
+
+    Per `.ai/rules/reasoning.md`, direct auth/OAuth/database/config fixes where
+    the likely edit is narrow are `medium`, never automatically `high`.
+    """
+    result = classify_task("fix the oauth redirect url for staging")
+    assert result["reasoning"] == "medium"
+    assert result["requires_approval"] is False
+    assert result["risk"] == "medium"
+
+
+def test_narrow_database_config_fix_is_medium():
+    result = classify_task("update the database connection string in config")
+    assert result["reasoning"] == "medium"
+    assert result["requires_approval"] is False
+
+
+def test_complex_auth_and_database_rewrite_is_high():
+    result = classify_task(
+        "rewrite the entire authentication architecture and migrate the database schema"
+    )
+    assert result["reasoning"] in {"high", "xhigh"}
+    assert result["requires_approval"] is True
+    assert result["risk"] == "high"
+    assert result["needs_plan"] is True
+
+
+def test_hyper_complex_security_is_xhigh():
+    result = classify_task(
+        "build a hyper complex fullstack payment system with encryption from scratch"
+    )
+    assert result["reasoning"] == "xhigh"
+    assert result["complexity"] == "extra_high"
+    assert result["requires_approval"] is True
+
+
+def test_architecture_keyword_pushes_to_medium_or_higher():
+    result = classify_task("refactor the architecture of the rendering pipeline")
+    assert result["task_type"] == "architecture"
+    assert result["reasoning"] in {"medium", "high", "xhigh"}
+    assert result["needs_plan"] is True
+
+
+def test_negation_does_not_trigger_auth_risk():
+    """`without auth` should not be treated as auth/security work."""
+    result = classify_task("write a one-file demo without auth or login")
+    # Without the auth flag, this should remain a tiny_create / small task,
+    # not get pushed up to medium or higher.
+    assert result["reasoning"] in {"none", "low"}
+    assert result["requires_approval"] is False
+
+
+def test_forced_reasoning_extra_high_normalizes_to_xhigh():
+    for forced in ("extra-high", "extra_high", "extra high"):
+        result = classify_task("simple task", forced_reasoning=forced)
+        assert result["reasoning"] == "xhigh", forced
+        assert result["complexity"] == "extra_high", forced
+
+
+def test_forced_reasoning_overrides_classification():
+    result = classify_task("fix typo", forced_reasoning="high")
+    assert result["reasoning"] == "high"
+    assert result["requires_approval"] is True
+
+
+def test_classification_returns_required_keys():
+    result = classify_task("anything")
+    expected_keys = {
+        "task_type",
+        "complexity",
+        "reasoning",
+        "risk",
+        "needs_plan",
+        "is_ui",
+        "is_tiny_create",
+        "requires_approval",
+    }
+    assert expected_keys.issubset(result.keys())
+
+
+@pytest.mark.parametrize(
+    "reasoning,expected_risk",
+    [
+        ("none", "low"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "high"),
+    ],
+)
+def test_risk_mapping_for_each_reasoning(reasoning, expected_risk):
+    result = classify_task("something", forced_reasoning=reasoning)
+    assert result["risk"] == expected_risk
+
+
+def test_russian_easy_error_with_bug_keyword_is_none_reasoning():
+    """A Russian phrase that has both a bug marker (`ошибк`) and an easy-error
+    marker (`опечат`) should hit the `is_easy_error` path and be `none`."""
+    result = classify_task("ошибка опечатка в файле")
+    assert result["reasoning"] == "none"
+    assert result["task_type"] == "bugfix"
+
+
+def test_russian_rename_is_small_edit_none():
+    """Russian small-edit verb (`переименуй`/`переменная`) without bug markers
+    still hits `is_small_edit` via the `переменн` stem."""
+    result = classify_task("переменная rename")
+    assert result["reasoning"] == "none"
+    assert result["task_type"] == "small_edit"

--- a/tests/test_estimate_cost.py
+++ b/tests/test_estimate_cost.py
@@ -1,0 +1,54 @@
+"""Unit tests for aidev.estimate_cost."""
+
+import pytest
+
+from aidev import DEFAULT_BUDGET, estimate_cost
+
+
+@pytest.mark.parametrize(
+    "reasoning",
+    ["none", "low", "medium", "high", "xhigh"],
+)
+def test_default_budget_table_returns_known_value(reasoning):
+    classification = {"reasoning": reasoning}
+    expected = DEFAULT_BUDGET["estimated_call_cost_usd"][reasoning]
+    assert estimate_cost(classification, DEFAULT_BUDGET) == pytest.approx(expected)
+
+
+def test_unknown_reasoning_falls_back_to_medium_estimate():
+    classification = {"reasoning": "ultra-mega"}
+    expected = DEFAULT_BUDGET["estimated_call_cost_usd"]["medium"]
+    assert estimate_cost(classification, DEFAULT_BUDGET) == pytest.approx(expected)
+
+
+def test_custom_budget_table_is_respected():
+    custom = {
+        "estimated_call_cost_usd": {
+            "none": 0.001,
+            "low": 0.002,
+            "medium": 0.003,
+            "high": 0.004,
+            "xhigh": 0.005,
+        }
+    }
+    assert estimate_cost({"reasoning": "high"}, custom) == pytest.approx(0.004)
+
+
+def test_missing_cost_table_falls_back_to_defaults():
+    """A budget object without `estimated_call_cost_usd` should still work."""
+    assert estimate_cost({"reasoning": "low"}, {}) == pytest.approx(
+        DEFAULT_BUDGET["estimated_call_cost_usd"]["low"]
+    )
+
+
+def test_returns_float():
+    """Caller (`build_contract` budget percent) does float math on the result."""
+    cost = estimate_cost({"reasoning": "medium"}, DEFAULT_BUDGET)
+    assert isinstance(cost, float)
+
+
+def test_partial_custom_table_falls_back_to_internal_default_for_missing_key():
+    """If the custom table omits a key but provides 'medium', missing keys hit the
+    inner `.get('medium', 0.08)` fallback inside estimate_cost."""
+    custom = {"estimated_call_cost_usd": {"medium": 0.42}}
+    assert estimate_cost({"reasoning": "xhigh"}, custom) == pytest.approx(0.42)


### PR DESCRIPTION
## Summary

Adds focused pytest unit tests for the four `aidev.py` helpers called out in issue #11:

- `classify_task` — task type, reasoning level, risk, approval flag, and the `--forced-reasoning` aliasing. Includes a regression case for #7 (narrow OAuth/database fixes must stay at `medium`).
- `choose_model` and `normalize_model_name` — forced model override, the `gpt-5.4-pro` → `gpt-5.5` alias, reasoning → executor mapping, and the `manual` / `task` / `auto` supervisor modes (including catalog tag matching, wildcard fallback, and disabled-entry skipping).
- `estimate_cost` — per-tier lookups, fallback to `medium` for unknown reasoning, custom budget tables, and missing tables.
- `build_codex_prompt` — required front-of-prompt sections at every reasoning tier, the tier prompt-length cap is honored, the conditional sections (`FINAL RESPONSE`, `SCOPE` with rollback, `CONTRACT SUMMARY`, `TODO STAGE CONTRACT`) only fit at the tiers where there is budget headroom, the contract-summary block is valid JSON, and user-request text plus model name survive into the assembled output.

Closes #11.

## Why this shape

Per the team-lead's scope: **pure additions, no edits to `aidev.py`**. New files only:

- `pytest.ini` at repo root: `testpaths=tests`, `pythonpath=.`, plus `--strict-markers`.
- `tests/__init__.py` (empty package marker).
- `tests/conftest.py` to put the repo root on `sys.path` and pin `AIDEV_PROJECT_ROOT` so the module-level `ROOT` resolves predictably during import.
- Four test modules covering the four helpers.

Tests intentionally exercise the public function contracts only — no monkeypatching of internals, no I/O, no subprocesses — so they are fast and stable.

## Notes on the prompt-length contract

While writing the `build_codex_prompt` tests I confirmed (and locked in) a non-obvious behavior: at the lower reasoning tiers (`none` cap = 1400 chars, `low` = 1800), the boilerplate produced by `build_enhanced_prompt` / `build_technical_prompt` already saturates the budget, so the trailing sections (`SCOPE`, `FINAL RESPONSE`, etc.) get truncated by the outer `trim_chars`. The tests assert the realistic contract: required front sections always survive at every tier, optional later sections are only guaranteed at `medium`+ (rollback) / `high`+ (FINAL RESPONSE, CONTRACT SUMMARY, TODO STAGE CONTRACT). If the prompt budgets ever change, these tests will alert.

## Test plan

- [ ] `python -m pip install pytest` (one-time, dev only)
- [ ] `python -m pytest tests/` from repo root — expects 71 passed
- [ ] `cd desktop && npm run smoke` — existing smoke still passes (no production code changed)
- [ ] CI: confirm pytest discovery works without any extra flags (the `pytest.ini` handles `pythonpath` for fresh checkouts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)