### PR TITLE
Fix #3: enforce budget guard outside supervisor

### DIFF
--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -3,6 +3,7 @@ const path = require("path");
 const fs = require("fs");
 const cp = require("child_process");
 const crypto = require("crypto");
+const policy = require("./policy");
 
 const APP_ROOT = path.resolve(__dirname, "..", "..");
 const APP_AI_DIR = path.join(APP_ROOT, ".ai");
@@ -276,17 +277,33 @@ function refreshProjectSummary(root) {
       readText(path.join(selected, "README.md")),
     ].join("\n\n").trim().slice(0, 12000);
     if (source) {
+      const summaryModel = current.directModel || current.model || "gpt-5.4-mini";
+      const summaryReasoning = "none";
+      const summaryPrompt = `Write one short project summary for a sidebar. Max 12 words. No markdown.\n\n${source}`;
+      const summaryRunId = nowRunId("summary-refresh");
+      const projectAiDir = path.join(selected, ".ai");
+      const gate = policy.preflight({
+        projectAiDir,
+        model: summaryModel,
+        reasoning: summaryReasoning,
+        promptText: summaryPrompt,
+        budgetGuard: current.budgetGuard !== false,
+        approvalGranted: false,
+      });
+      if (!gate.ok) {
+        return touchProject(selected, { summary: fallback });
+      }
       const result = cp.spawnSync(codex, [
         "exec",
         "-",
         "--cd",
         selected,
         "-m",
-        current.directModel || current.model || "gpt-5.4-mini",
+        summaryModel,
         "-s",
         "read-only",
       ], {
-        input: `Write one short project summary for a sidebar. Max 12 words. No markdown.\n\n${source}`,
+        input: summaryPrompt,
         cwd: selected,
         shell: needsShell(codex),
         windowsHide: true,
@@ -295,7 +312,17 @@ function refreshProjectSummary(root) {
         timeout: 120000,
       });
       const text = String(result.stdout || "").split(/\r?\n/).map((line) => line.trim()).filter(Boolean).slice(-1)[0];
-      if (result.status === 0 && text) summary = text.replace(/^["']|["']$/g, "").slice(0, 120);
+      if (result.status === 0 && text) {
+        summary = text.replace(/^["']|["']$/g, "").slice(0, 120);
+        try {
+          policy.appendLedger(projectAiDir, {
+            runId: summaryRunId,
+            model: summaryModel,
+            reasoning: summaryReasoning,
+            cost: gate.budgetStatus.estimated_cost_usd,
+          });
+        } catch {}
+      }
     }
   }
   return touchProject(selected, { summary });
@@ -1521,6 +1548,29 @@ ipcMain.handle("run:direct", (_event, payload) => {
     route: payload.routeDecision || { route: "manual_direct" },
     created_at: new Date().toISOString(),
   });
+  const directRunOptions = payload.options || {};
+  const directProjectAiDir = detached ? APP_AI_DIR : projectAiDir();
+  const directGate = policy.preflight({
+    projectAiDir: directProjectAiDir,
+    model: directModel,
+    reasoning: directReasoning,
+    promptText: fullPrompt,
+    budgetGuard: merged.budgetGuard !== false,
+    approvalGranted: Boolean(directRunOptions.approveHigh),
+    forceBudget: Boolean(directRunOptions.forceBudget),
+  });
+  if (!directGate.ok) {
+    writeJson(path.join(runDir, "audit.json"), {
+      status: directGate.reason,
+      changed_files: [],
+      scope_warnings: [],
+      codex_ok: false,
+      codex_returncode: null,
+      budget: directGate.budgetStatus,
+      created_at: new Date().toISOString(),
+    });
+    throw new Error(directGate.error);
+  }
   const beforeSnapshot = detached ? {} : snapshot_files_safe();
   writeJson(path.join(runDir, "before-state.json"), { git: { has_git: detached ? false : hasGitRepository() }, files: beforeSnapshot });
   if (!detached) backupBeforeFiles(runDir, beforeSnapshot);
@@ -1561,7 +1611,7 @@ ipcMain.handle("run:direct", (_event, payload) => {
         codex_returncode: code,
         created_at: new Date().toISOString(),
       });
-      writeJson(path.join(runDir, "usage.json"), buildUsageReport({
+      const usage = buildUsageReport({
         model: directModel,
         reasoning: directReasoning,
         prompt: fullPrompt,
@@ -1570,7 +1620,23 @@ ipcMain.handle("run:direct", (_event, payload) => {
         lastMessage,
         startedAt,
         routeDecision: payload.routeDecision || { route: "manual_direct" },
-      }));
+      });
+      writeJson(path.join(runDir, "usage.json"), usage);
+      try {
+        const actualCost = Number(usage?.cost?.actual_usd);
+        const estimatedCost = Number(usage?.cost?.estimated_usd);
+        const ledgerCost = Number.isFinite(actualCost) && actualCost > 0
+          ? actualCost
+          : (Number.isFinite(estimatedCost) ? estimatedCost : directGate.budgetStatus.estimated_cost_usd);
+        policy.appendLedger(directProjectAiDir, {
+          runId: directRunId,
+          model: directModel,
+          reasoning: directReasoning,
+          cost: ledgerCost,
+        });
+      } catch (error) {
+        console.error("Direct run ledger append failed:", error);
+      }
     },
   });
   return true;

--- a/desktop/src/policy.js
+++ b/desktop/src/policy.js
@@ -1,0 +1,251 @@
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_BUDGET = {
+  session_budget_usd: 5.0,
+  request_budget_usd: 0.5,
+  retry_budget_usd: 0.15,
+  max_codex_calls_per_request: 2,
+  daily_codex_call_limit: 20,
+  daily_high_call_limit: 3,
+  daily_xhigh_call_limit: 1,
+  warn_at_percent: 80,
+  block_at_percent: 95,
+  estimated_call_cost_usd: {
+    none: 0.01,
+    low: 0.03,
+    medium: 0.08,
+    high: 0.25,
+    xhigh: 0.6,
+  },
+  model_token_prices_usd_per_1m: {
+    "gpt-5.4-mini": { input: 0.75, cached_input: 0.075, output: 4.5 },
+    "gpt-5.4": { input: 2.5, cached_input: 0.25, output: 15.0 },
+    "gpt-5.5": { input: 2.5, cached_input: 0.25, output: 15.0 },
+    "gpt-5.4-nano": { input: 0.2, cached_input: 0.02, output: 1.25 },
+  },
+};
+
+const REQUIRES_APPROVAL = new Set(["high", "xhigh"]);
+
+function readJson(file, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function budgetFile(projectAiDir) {
+  return path.join(projectAiDir, "budget", "budget.json");
+}
+
+function ledgerFile(projectAiDir) {
+  return path.join(projectAiDir, "budget", "ledger.jsonl");
+}
+
+function loadBudget(projectAiDir) {
+  const fromDisk = readJson(budgetFile(projectAiDir), {});
+  return {
+    ...DEFAULT_BUDGET,
+    ...fromDisk,
+    estimated_call_cost_usd: { ...DEFAULT_BUDGET.estimated_call_cost_usd, ...(fromDisk.estimated_call_cost_usd || {}) },
+    model_token_prices_usd_per_1m: { ...DEFAULT_BUDGET.model_token_prices_usd_per_1m, ...(fromDisk.model_token_prices_usd_per_1m || {}) },
+  };
+}
+
+function ledgerEntries(projectAiDir) {
+  const file = ledgerFile(projectAiDir);
+  if (!fs.existsSync(file)) return [];
+  const out = [];
+  for (const line of fs.readFileSync(file, "utf8").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      out.push(JSON.parse(trimmed));
+    } catch {}
+  }
+  return out;
+}
+
+function sessionEstimatedSpend(projectAiDir) {
+  let total = 0;
+  for (const entry of ledgerEntries(projectAiDir)) {
+    const value = Number(entry?.estimated_cost_usd);
+    if (Number.isFinite(value)) total += value;
+  }
+  return total;
+}
+
+function todayIsoDate(now) {
+  const d = now instanceof Date ? now : new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function dailyUsage(projectAiDir, now) {
+  const today = todayIsoDate(now);
+  const usage = { total: 0, high: 0, xhigh: 0 };
+  for (const entry of ledgerEntries(projectAiDir)) {
+    const created = String(entry?.created_at || "");
+    if (!created.startsWith(today)) continue;
+    usage.total += 1;
+    if (entry?.reasoning === "high") usage.high += 1;
+    if (entry?.reasoning === "xhigh") usage.xhigh += 1;
+  }
+  return usage;
+}
+
+function modelTokenPrice(model, budget) {
+  const table = budget.model_token_prices_usd_per_1m || DEFAULT_BUDGET.model_token_prices_usd_per_1m;
+  const lower = String(model || "").toLowerCase();
+  const keys = Object.keys(table).sort((a, b) => b.length - a.length);
+  for (const key of keys) {
+    if (lower.includes(key.toLowerCase())) return table[key];
+  }
+  return null;
+}
+
+function estimateTokens(text) {
+  if (!text) return 0;
+  return Math.max(1, Math.floor(String(text).length / 4));
+}
+
+function expectedOutputTokens(reasoning) {
+  return {
+    none: 300,
+    low: 800,
+    medium: 1800,
+    high: 4000,
+    xhigh: 8000,
+  }[reasoning] || 1200;
+}
+
+function estimateRequestCost({ model, reasoning, promptText, budget }) {
+  const cfg = budget || DEFAULT_BUDGET;
+  const price = modelTokenPrice(model, cfg);
+  const inputTokens = estimateTokens(promptText);
+  const outputTokens = expectedOutputTokens(reasoning);
+  if (price) {
+    const longCtx = String(model || "").toLowerCase().includes("gpt-5.4") && inputTokens > 272000;
+    const inputMul = longCtx ? 2 : 1;
+    const outputMul = longCtx ? 1.5 : 1;
+    const usd = ((inputTokens * Number(price.input || 0) * inputMul) + (outputTokens * Number(price.output || 0) * outputMul)) / 1_000_000;
+    if (usd > 0) return Number(usd.toFixed(6));
+  }
+  const tier = (cfg.estimated_call_cost_usd || {})[reasoning];
+  return Number(((Number.isFinite(tier) ? tier : 0.08)).toFixed(6));
+}
+
+function budgetCheck({ cost, budget, reasoning, projectAiDir, now }) {
+  const sessionBudget = Number(budget.session_budget_usd) || 0;
+  const requestBudget = Number(budget.request_budget_usd) || 0;
+  const spent = sessionEstimatedSpend(projectAiDir);
+  const sessionAfter = spent + cost;
+  const sessionPercent = sessionBudget ? (100 * sessionAfter) / sessionBudget : 100;
+  const requestPercent = requestBudget ? (100 * cost) / requestBudget : 100;
+  const blockAt = Number(budget.block_at_percent) || 95;
+  const warnAt = Number(budget.warn_at_percent) || 80;
+
+  const usage = dailyUsage(projectAiDir, now);
+  const dailyLimit = Number(budget.daily_codex_call_limit) || 0;
+  const highLimit = Number(budget.daily_high_call_limit) || 0;
+  const xhighLimit = Number(budget.daily_xhigh_call_limit) || 0;
+  let callLimitBlocked = dailyLimit > 0 && usage.total >= dailyLimit;
+  if (reasoning === "high" && highLimit > 0) callLimitBlocked = callLimitBlocked || usage.high >= highLimit;
+  if (reasoning === "xhigh" && xhighLimit > 0) callLimitBlocked = callLimitBlocked || usage.xhigh >= xhighLimit;
+
+  const blocked = sessionPercent >= blockAt || requestPercent >= blockAt || callLimitBlocked;
+  const warning = sessionPercent >= warnAt || requestPercent >= warnAt;
+  return {
+    estimated_cost_usd: Number(cost.toFixed(4)),
+    session_spent_before_usd: Number(spent.toFixed(4)),
+    session_after_usd: Number(sessionAfter.toFixed(4)),
+    session_percent_after: Number(sessionPercent.toFixed(2)),
+    request_percent: Number(requestPercent.toFixed(2)),
+    daily_usage: usage,
+    daily_limits: { total: dailyLimit, high: highLimit, xhigh: xhighLimit },
+    call_limit_blocked: callLimitBlocked,
+    blocked,
+    warning,
+  };
+}
+
+function requiresApproval(reasoning) {
+  return REQUIRES_APPROVAL.has(String(reasoning || "").toLowerCase());
+}
+
+function preflight({
+  projectAiDir,
+  model,
+  reasoning,
+  promptText,
+  budgetGuard = true,
+  approvalGranted = false,
+  forceBudget = false,
+  now,
+}) {
+  const budget = loadBudget(projectAiDir);
+  const cost = estimateRequestCost({ model, reasoning, promptText, budget });
+  const status = budgetCheck({ cost, budget, reasoning, projectAiDir, now });
+  const needsApproval = requiresApproval(reasoning);
+  if (budgetGuard && status.blocked && !forceBudget) {
+    return {
+      ok: false,
+      blocked: "budget",
+      reason: "blocked_by_budget",
+      error: status.call_limit_blocked
+        ? `Blocked by daily call limit (${status.daily_usage.total}/${status.daily_limits.total}).`
+        : `Blocked by budget guard (request ${status.request_percent}% / session ${status.session_percent_after}%).`,
+      budgetStatus: status,
+      requiresApproval: needsApproval,
+    };
+  }
+  if (needsApproval && !approvalGranted) {
+    return {
+      ok: false,
+      blocked: "approval",
+      reason: "blocked_by_approval",
+      error: `Reasoning level "${reasoning}" requires explicit approval.`,
+      budgetStatus: status,
+      requiresApproval: true,
+    };
+  }
+  return {
+    ok: true,
+    budgetStatus: status,
+    requiresApproval: needsApproval,
+  };
+}
+
+function appendLedger(projectAiDir, { runId, model, reasoning, cost, now }) {
+  const file = ledgerFile(projectAiDir);
+  ensureDir(path.dirname(file));
+  const entry = {
+    run_id: String(runId || ""),
+    model: String(model || ""),
+    reasoning: String(reasoning || ""),
+    estimated_cost_usd: Number(Number(cost || 0).toFixed(4)),
+    created_at: (now instanceof Date ? now : new Date()).toISOString().replace(/\.\d{3}Z$/, ""),
+  };
+  fs.appendFileSync(file, JSON.stringify(entry) + "\n", "utf8");
+  return entry;
+}
+
+module.exports = {
+  DEFAULT_BUDGET,
+  loadBudget,
+  preflight,
+  budgetCheck,
+  estimateRequestCost,
+  sessionEstimatedSpend,
+  dailyUsage,
+  appendLedger,
+  requiresApproval,
+};

--- a/desktop/test/policy.test.js
+++ b/desktop/test/policy.test.js
@@ -1,0 +1,199 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const assert = require("node:assert/strict");
+
+const policy = require("../src/policy");
+
+function tempProjectAi() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aidev-policy-"));
+  const aiDir = path.join(root, ".ai");
+  fs.mkdirSync(path.join(aiDir, "budget"), { recursive: true });
+  return { root, aiDir };
+}
+
+function writeBudget(aiDir, budget) {
+  fs.writeFileSync(path.join(aiDir, "budget", "budget.json"), JSON.stringify(budget));
+}
+
+function writeLedger(aiDir, lines) {
+  fs.writeFileSync(
+    path.join(aiDir, "budget", "ledger.jsonl"),
+    lines.map((line) => JSON.stringify(line)).join("\n") + (lines.length ? "\n" : ""),
+  );
+}
+
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`  FAIL  ${name}`);
+    console.error(err);
+  }
+}
+
+console.log("policy:");
+
+test("preflight passes when budget is clean and reasoning is low", () => {
+  const { aiDir } = tempProjectAi();
+  const result = policy.preflight({
+    projectAiDir: aiDir,
+    model: "gpt-5.4-mini",
+    reasoning: "low",
+    promptText: "small task",
+  });
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.equal(result.requiresApproval, false);
+});
+
+test("preflight refuses high reasoning unless approval is granted", () => {
+  const { aiDir } = tempProjectAi();
+  const blocked = policy.preflight({
+    projectAiDir: aiDir,
+    model: "gpt-5.4-mini",
+    reasoning: "high",
+    promptText: "big task",
+  });
+  assert.equal(blocked.ok, false);
+  assert.equal(blocked.blocked, "approval");
+  assert.equal(blocked.reason, "blocked_by_approval");
+
+  const approved = policy.preflight({
+    projectAiDir: aiDir,
+    model: "gpt-5.4-mini",
+    reasoning: "high",
+    promptText: "big task",
+    approvalGranted: true,
+  });
+  assert.equal(approved.ok, true);
+});
+
+test("preflight blocks when daily call limit reached", () => {
+  const { aiDir } = tempProjectAi();
+  writeBudget(aiDir, { daily_codex_call_limit: 2 });
+  const today = new Date().toISOString().slice(0, 10);
+  writeLedger(aiDir, [
+    { run_id: "a", model: "m", reasoning: "low", estimated_cost_usd: 0.01, created_at: `${today}T00:00:00` },
+    { run_id: "b", model: "m", reasoning: "low", estimated_cost_usd: 0.01, created_at: `${today}T00:00:01` },
+  ]);
+  const result = policy.preflight({
+    projectAiDir: aiDir,
+    model: "gpt-5.4-mini",
+    reasoning: "low",
+    promptText: "x",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.blocked, "budget");
+  assert.equal(result.reason, "blocked_by_budget");
+  assert.equal(result.budgetStatus.call_limit_blocked, true);
+});
+
+test("preflight blocks when session spend would exceed budget threshold", () => {
+  const { aiDir } = tempProjectAi();
+  writeBudget(aiDir, { session_budget_usd: 1.0, request_budget_usd: 5.0, block_at_percent: 95 });
+  const today = new Date().toISOString().slice(0, 10);
+  writeLedger(aiDir, [
+    { run_id: "a", model: "m", reasoning: "low", estimated_cost_usd: 0.99, created_at: `${today}T00:00:00` },
+  ]);
+  const result = policy.preflight({
+    projectAiDir: aiDir,
+    model: "gpt-5.4-mini",
+    reasoning: "low",
+    promptText: "x".repeat(200),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.blocked, "budget");
+});
+
+test("preflight respects budgetGuard:false (does not block on budget but still blocks on approval)", () => {
+  const { aiDir } = tempProjectAi();
+  writeBudget(aiDir, { daily_codex_call_limit: 1 });
+  const today = new Date().toISOString().slice(0, 10);
+  writeLedger(aiDir, [
+    { run_id: "a", model: "m", reasoning: "low", estimated_cost_usd: 0.01, created_at: `${today}T00:00:00` },
+  ]);
+  const noBudget = policy.preflight({
+    projectAiDir: aiDir,
+    model: "gpt-5.4-mini",
+    reasoning: "low",
+    promptText: "x",
+    budgetGuard: false,
+  });
+  assert.equal(noBudget.ok, true, JSON.stringify(noBudget));
+
+  const stillNeedsApproval = policy.preflight({
+    projectAiDir: aiDir,
+    model: "gpt-5.4-mini",
+    reasoning: "high",
+    promptText: "x",
+    budgetGuard: false,
+  });
+  assert.equal(stillNeedsApproval.ok, false);
+  assert.equal(stillNeedsApproval.blocked, "approval");
+});
+
+test("preflight respects forceBudget override", () => {
+  const { aiDir } = tempProjectAi();
+  writeBudget(aiDir, { daily_codex_call_limit: 1 });
+  const today = new Date().toISOString().slice(0, 10);
+  writeLedger(aiDir, [
+    { run_id: "a", model: "m", reasoning: "low", estimated_cost_usd: 0.01, created_at: `${today}T00:00:00` },
+  ]);
+  const result = policy.preflight({
+    projectAiDir: aiDir,
+    model: "gpt-5.4-mini",
+    reasoning: "low",
+    promptText: "x",
+    forceBudget: true,
+  });
+  assert.equal(result.ok, true);
+});
+
+test("appendLedger writes a JSONL entry session spend can read", () => {
+  const { aiDir } = tempProjectAi();
+  policy.appendLedger(aiDir, { runId: "r1", model: "gpt-5.4-mini", reasoning: "low", cost: 0.05 });
+  policy.appendLedger(aiDir, { runId: "r2", model: "gpt-5.4-mini", reasoning: "low", cost: 0.07 });
+  assert.ok(Math.abs(policy.sessionEstimatedSpend(aiDir) - 0.12) < 1e-9);
+});
+
+test("dailyUsage counts today's entries by reasoning", () => {
+  const { aiDir } = tempProjectAi();
+  const today = new Date().toISOString().slice(0, 10);
+  writeLedger(aiDir, [
+    { run_id: "a", model: "m", reasoning: "low", estimated_cost_usd: 0.01, created_at: `${today}T00:00:00` },
+    { run_id: "b", model: "m", reasoning: "high", estimated_cost_usd: 0.01, created_at: `${today}T00:01:00` },
+    { run_id: "c", model: "m", reasoning: "high", estimated_cost_usd: 0.01, created_at: `${today}T00:02:00` },
+    { run_id: "d", model: "m", reasoning: "xhigh", estimated_cost_usd: 0.01, created_at: `${today}T00:03:00` },
+    { run_id: "e", model: "m", reasoning: "low", estimated_cost_usd: 0.01, created_at: "1990-01-01T00:00:00" },
+  ]);
+  const usage = policy.dailyUsage(aiDir);
+  assert.equal(usage.total, 4, "older-day entry should not be counted");
+  assert.equal(usage.high, 2);
+  assert.equal(usage.xhigh, 1);
+});
+
+test("loadBudget merges defaults with on-disk values", () => {
+  const { aiDir } = tempProjectAi();
+  writeBudget(aiDir, { session_budget_usd: 20 });
+  const merged = policy.loadBudget(aiDir);
+  assert.equal(merged.session_budget_usd, 20);
+  assert.equal(merged.daily_codex_call_limit, 20, "default daily limit should be preserved");
+  assert.ok(merged.estimated_call_cost_usd.medium > 0, "default per-tier costs should be preserved");
+});
+
+test("requiresApproval flags high and xhigh", () => {
+  assert.equal(policy.requiresApproval("none"), false);
+  assert.equal(policy.requiresApproval("low"), false);
+  assert.equal(policy.requiresApproval("medium"), false);
+  assert.equal(policy.requiresApproval("high"), true);
+  assert.equal(policy.requiresApproval("xhigh"), true);
+});
+
+if (failed) {
+  console.error(`\n${failed} test(s) failed.`);
+  process.exit(1);
+}
+console.log("\nAll policy tests passed.");

--- a/desktop/test/smoke.js
+++ b/desktop/test/smoke.js
@@ -215,4 +215,6 @@ assert.ok(latestUsage.tokens.total > 0, "usage should record token estimate");
 assert.ok(latestUsage.context.used_percent >= 0, "usage should record context fill");
 assert.ok(latestUsage.cost.estimated_usd >= 0, "usage should record cost estimate");
 
+cp.execFileSync(process.execPath, [path.resolve(__dirname, "policy.test.js")], { stdio: "inherit" });
+
 console.log("Smoke checks passed.");


### PR DESCRIPTION
## Summary
- Adds `desktop/src/policy.js` as the JS-side single source of truth for preflight budget checks, daily call limits, high-reasoning approval, and ledger writes. It mirrors aidev.py's policy shape so the audit and ledger files stay compatible across modes.
- `run:direct` now calls `policy.preflight` before spawning Codex. Blocked runs write `audit.json` with `status: blocked_by_budget` or `blocked_by_approval` (matching the supervisor audit shape) and throw so the renderer's existing `safeInvoke` error handler surfaces the message. Successful runs append to `.ai/budget/ledger.jsonl` from the usage report's actual or estimated cost. Honors `merged.budgetGuard`, `runOptions.approveHigh`, and `runOptions.forceBudget` that the renderer already collects for supervisor.
- `refreshProjectSummary` runs the same preflight before the read-only Codex call and falls back to the local summary string if blocked. Successful calls also append to the ledger so daily limits actually count summary refreshes.
- Supervisor (`run:supervisor`) is unchanged because aidev.py already runs the same checks internally; the JS preflight would either double-gate or diverge. Centralizing the duplicated default-budget table is tracked as #9.

## Test plan
- [x] `cd desktop && npm run check`
- [x] `cd desktop && npm run smoke` (now includes policy unit tests)
- [x] New `desktop/test/policy.test.js` covers:
  - clean preflight pass for low reasoning
  - high reasoning refused without approval, accepted with `approvalGranted: true`
  - daily call limit block via `daily_codex_call_limit`
  - session budget block via session-spend math
  - `budgetGuard: false` bypasses budget but still gates approval
  - `forceBudget: true` overrides daily call limit
  - appendLedger -> sessionEstimatedSpend round-trip
  - dailyUsage counts today by reasoning, ignores older days
  - loadBudget merges defaults with on-disk values
  - requiresApproval flags only high/xhigh
- [ ] Manual: in the desktop app, set `budget.json` daily_codex_call_limit to 1, fire two direct runs, confirm the second is refused with a clear error and `audit.json` shows `blocked_by_budget`.
- [ ] Manual: set Direct reasoning to high without approve-high, fire a direct run, confirm refusal with `blocked_by_approval`. Then set `runOptions.approveHigh` (via the supervisor approval card flow if reused) and confirm it runs.

Closes #3