### PR TITLE
Fix #6: stop blocking main process on long Codex calls

### DIFF
--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -3,6 +3,7 @@ const path = require("path");
 const fs = require("fs");
 const cp = require("child_process");
 const crypto = require("crypto");
+const { spawnAsync } = require("./spawn-async");
 
 const APP_ROOT = path.resolve(__dirname, "..", "..");
 const APP_AI_DIR = path.join(APP_ROOT, ".ai");
@@ -263,7 +264,7 @@ function projectSummary(root) {
   return "No summary yet.";
 }
 
-function refreshProjectSummary(root) {
+async function refreshProjectSummary(root) {
   const current = settings();
   const selected = path.resolve(root || projectRoot());
   const fallback = projectSummary(selected);
@@ -276,7 +277,7 @@ function refreshProjectSummary(root) {
       readText(path.join(selected, "README.md")),
     ].join("\n\n").trim().slice(0, 12000);
     if (source) {
-      const result = cp.spawnSync(codex, [
+      const result = await spawnAsync(codex, [
         "exec",
         "-",
         "--cd",
@@ -289,7 +290,6 @@ function refreshProjectSummary(root) {
         input: `Write one short project summary for a sidebar. Max 12 words. No markdown.\n\n${source}`,
         cwd: selected,
         shell: needsShell(codex),
-        windowsHide: true,
         encoding: "utf8",
         env: processEnvForSettings(current),
         timeout: 120000,
@@ -1406,7 +1406,7 @@ ipcMain.handle("run:supervisor", (_event, payload) => {
   return true;
 });
 
-ipcMain.handle("run:supervisor-analyze", (_event, payload) => {
+ipcMain.handle("run:supervisor-analyze", async (_event, payload) => {
   const current = settings();
   const merged = { ...current, ...(payload.settings || {}) };
   const prompt = String(payload.prompt || "").trim();
@@ -1420,13 +1420,12 @@ ipcMain.handle("run:supervisor-analyze", (_event, payload) => {
     throw new Error(`Python command "${current.pythonPath}" was not found in PATH.`);
   }
 
-  const result = cp.spawnSync(
+  const result = await spawnAsync(
     pythonCommand,
     supervisorArgs(promptWithAttachments, false, { ...(payload.settings || {}), requestFeature: feature }, payload.options),
     {
       cwd: projectRoot(),
       shell: needsShell(pythonCommand),
-      windowsHide: true,
       encoding: "utf8",
       env: processEnvForSettings({ ...merged, selectedModel: merged.supervisorManualModel || merged.supervisorModel }),
       timeout: 120000,
@@ -1758,7 +1757,7 @@ ipcMain.handle("workspace:removeProject", (_event, root) => {
   return current;
 });
 
-ipcMain.handle("workspace:refreshProjectSummary", (_event, root) => refreshProjectSummary(root));
+ipcMain.handle("workspace:refreshProjectSummary", async (_event, root) => refreshProjectSummary(root));
 
 ipcMain.handle("budget:save", (_event, value) => {
   const file = path.join(projectAiDir(), "budget", "budget.json");

--- a/desktop/src/spawn-async.js
+++ b/desktop/src/spawn-async.js
@@ -1,0 +1,48 @@
+const cp = require("child_process");
+
+function spawnAsync(command, args, options = {}) {
+  const { input, timeout, encoding = "utf8", ...rest } = options;
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = cp.spawn(command, args, { ...rest, windowsHide: true });
+    } catch (error) {
+      resolve({ status: null, signal: null, stdout: "", stderr: "", error });
+      return;
+    }
+    let stdout = "";
+    let stderr = "";
+    let timer = null;
+    let timedOut = false;
+    let settled = false;
+
+    const decode = (chunk) => (Buffer.isBuffer(chunk) && encoding ? chunk.toString(encoding) : String(chunk));
+    if (child.stdout) child.stdout.on("data", (chunk) => { stdout += decode(chunk); });
+    if (child.stderr) child.stderr.on("data", (chunk) => { stderr += decode(chunk); });
+
+    const finish = (status, signal, error) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve({ status, signal, stdout, stderr, error: error || null, timedOut });
+    };
+
+    child.on("error", (error) => finish(null, null, error));
+    child.on("close", (status, signal) => finish(status, signal || null, null));
+
+    if (typeof input === "string" && child.stdin) {
+      child.stdin.on("error", () => {});
+      child.stdin.write(input);
+      child.stdin.end();
+    }
+
+    if (timeout && Number.isFinite(timeout) && timeout > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        try { child.kill(); } catch {}
+      }, timeout);
+    }
+  });
+}
+
+module.exports = { spawnAsync };

--- a/desktop/test/smoke.js
+++ b/desktop/test/smoke.js
@@ -215,4 +215,6 @@ assert.ok(latestUsage.tokens.total > 0, "usage should record token estimate");
 assert.ok(latestUsage.context.used_percent >= 0, "usage should record context fill");
 assert.ok(latestUsage.cost.estimated_usd >= 0, "usage should record cost estimate");
 
+cp.execFileSync(process.execPath, [path.resolve(__dirname, "spawn-async.test.js")], { stdio: "inherit" });
+
 console.log("Smoke checks passed.");

--- a/desktop/test/spawn-async.test.js
+++ b/desktop/test/spawn-async.test.js
@@ -1,0 +1,77 @@
+const assert = require("node:assert/strict");
+const { spawnAsync } = require("../src/spawn-async");
+
+let failed = 0;
+function test(name, fn) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ok  ${name}`))
+    .catch((err) => {
+      failed += 1;
+      console.error(`  FAIL  ${name}`);
+      console.error(err);
+    });
+}
+
+console.log("spawnAsync:");
+
+(async () => {
+  await test("captures stdout/stderr and exit status from a short command", async () => {
+    const result = await spawnAsync(process.execPath, ["-e", "process.stdout.write('hi'); process.stderr.write('err'); process.exit(0)"]);
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, "hi");
+    assert.equal(result.stderr, "err");
+  });
+
+  await test("propagates non-zero exit codes without throwing", async () => {
+    const result = await spawnAsync(process.execPath, ["-e", "process.exit(7)"]);
+    assert.equal(result.status, 7);
+    assert.equal(result.error, null);
+  });
+
+  await test("times out and reports timedOut=true", async () => {
+    const t0 = Date.now();
+    const result = await spawnAsync(process.execPath, ["-e", "setTimeout(() => {}, 5000)"], { timeout: 200 });
+    const elapsed = Date.now() - t0;
+    assert.equal(result.timedOut, true);
+    assert.ok(elapsed < 2000, `should kill quickly after timeout, took ${elapsed}ms`);
+  });
+
+  await test("two long calls run in parallel, not serially (proves non-blocking)", async () => {
+    const sleepScript = "setTimeout(() => process.exit(0), 600)";
+    const t0 = Date.now();
+    const [a, b] = await Promise.all([
+      spawnAsync(process.execPath, ["-e", sleepScript]),
+      spawnAsync(process.execPath, ["-e", sleepScript]),
+    ]);
+    const elapsed = Date.now() - t0;
+    assert.equal(a.status, 0);
+    assert.equal(b.status, 0);
+    assert.ok(
+      elapsed < 1100,
+      `two 600ms calls in parallel should finish under ~1100ms, took ${elapsed}ms (serial would be ~1200ms+)`,
+    );
+  });
+
+  await test("forwards stdin input to the child", async () => {
+    const result = await spawnAsync(
+      process.execPath,
+      ["-e", "let buf=''; process.stdin.on('data', c => buf += c); process.stdin.on('end', () => { process.stdout.write(buf.toUpperCase()); process.exit(0); })"],
+      { input: "hello world" },
+    );
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, "HELLO WORLD");
+  });
+
+  await test("returns error when the command does not exist", async () => {
+    const result = await spawnAsync("definitely-not-a-real-command-xyz-12345", []);
+    assert.ok(result.error, "should populate error field");
+    assert.equal(result.status, null);
+  });
+
+  if (failed) {
+    console.error(`\n${failed} test(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll spawn-async tests passed.");
+})();


### PR DESCRIPTION
## Summary
- The two longest blocking calls in IPC handlers — `refreshProjectSummary`'s `codex exec` and `run:supervisor-analyze`'s `python aidev.py` — both ran via `child_process.spawnSync` with a 120-second timeout, freezing the renderer for the duration.
- Adds `desktop/src/spawn-async.js`: a Promise wrapper around `child_process.spawn` that buffers stdout/stderr, forwards stdin input, enforces a kill-on-timeout, and resolves with `{ status, signal, stdout, stderr, error, timedOut }` (it does not throw on non-zero exit). Always passes `windowsHide: true`.
- Converts both call sites to `await spawnAsync(...)` and marks the affected IPC handlers `async`. The Node event loop stays free, so other IPC and renderer messages keep flowing while a Codex/Python call is in flight.
- Other sync paths flagged in the issue body (`commandExists` / `hasGitRepository` which only run a fast `which`/`where.exe`; `git restore` in undo) are short-lived; the heavier snapshot/copy paths are scoped to #4 by the team-lead's queue and are not touched here.

## Test plan
- [x] `cd desktop && npm run check`
- [x] `cd desktop && npm run smoke`
- [x] New `desktop/test/spawn-async.test.js` covers:
  - stdout/stderr capture and exit status from a short command
  - non-zero exit code propagation without throwing
  - timeout kills the child and reports `timedOut: true`
  - stdin input forwarding
  - missing-command produces an `error` field instead of throwing
  - **two ~600ms calls run under ~1100ms wall-clock** (proves the helper does not block — serial would be ~1200ms+)
- [ ] Manual: in the desktop app, click "Refresh project summary" on a project; confirm the renderer stays responsive (other tabs clickable, heartbeats keep ticking) until the summary returns.
- [ ] Manual: send a supervisor analyze request; confirm IPCs from other panels still go through during the analyze call.

Closes #6