### PR TITLE
Add node:test main-process tests for desktop/src/main.js (close #13)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -8,7 +8,8 @@
     "start": "electron .",
     "start:project": "electron . --project",
     "check": "node --check src/main.js && node --check src/preload.js && node --check src/renderer/app.js",
-    "smoke": "node test/smoke.js"
+    "smoke": "node test/smoke.js",
+    "test:main": "node --test --test-concurrency=1 \"test/main/*.test.js\""
   },
   "devDependencies": {
     "electron": "^39.2.6"

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -1793,3 +1793,28 @@ app.on("window-all-closed", () => {
 app.on("activate", () => {
   if (BrowserWindow.getAllWindows().length === 0) createWindow();
 });
+
+// Exposed for unit testing only. Electron's main entry point does not read its
+// own module exports, so this block is harmless at runtime.
+module.exports = {
+  attachmentKind,
+  allowedModelSet,
+  commandExists,
+  extractCliTokenUsage,
+  formatArg,
+  isReadableTextAttachment,
+  isSnapshotIgnored,
+  listRuns,
+  modelContextLimit,
+  modelTokenPrices,
+  needsShell,
+  normalizeModelName,
+  normalizeRel,
+  nowRunId,
+  providerBaseUrl,
+  providerForModel,
+  runMtime,
+  runSortKeys,
+  tokenCost,
+  validationCommandForRun,
+};

--- a/desktop/test/main/_loader.js
+++ b/desktop/test/main/_loader.js
@@ -1,0 +1,70 @@
+// Test loader for desktop/src/main.js.
+//
+// main.js requires `electron` at module load and then registers ~100
+// `ipcMain.handle(...)` listeners plus `app.whenReady().then(createWindow)`.
+// To unit-test the helpers exported at the bottom of main.js without spinning
+// up a real Electron environment, we pre-populate the Node module cache with a
+// no-op stub of the `electron` module. main.js then sees the stub when it
+// calls `require("electron")`, and the side-effect calls (ipcMain.handle, app
+// listeners, dialog/shell/Notification access) all hit safe noop methods.
+//
+// `app.whenReady` returns a never-resolving Promise so the trailing
+// `.then(createWindow)` never fires. That keeps BrowserWindow construction
+// from running in the test process.
+//
+// Tests should `require("./_loader.js")` instead of touching main.js directly.
+
+"use strict";
+
+const path = require("path");
+const Module = require("module");
+
+const electronPath = require.resolve("electron");
+
+const stubApp = {
+  whenReady: () => new Promise(() => {}),
+  on: () => stubApp,
+  quit: () => {},
+  getPath: (name) => {
+    if (name === "userData") return path.join(__dirname, "_userData");
+    if (name === "documents") return path.join(__dirname, "_documents");
+    return path.join(__dirname, `_${name}`);
+  },
+};
+
+const stubBrowserWindow = function () {
+  return { loadFile: () => {}, on: () => {}, webContents: { on: () => {}, send: () => {} } };
+};
+stubBrowserWindow.getAllWindows = () => [];
+
+const stubIpcMain = { handle: () => {}, on: () => {}, removeHandler: () => {} };
+const stubShell = { openPath: () => Promise.resolve("") };
+const stubDialog = {
+  showOpenDialog: async () => ({ canceled: true, filePaths: [] }),
+  showSaveDialog: async () => ({ canceled: true, filePath: "" }),
+};
+function StubNotification() {
+  return { show: () => {} };
+}
+StubNotification.isSupported = () => false;
+
+const stubModule = new Module(electronPath);
+stubModule.id = electronPath;
+stubModule.filename = electronPath;
+stubModule.loaded = true;
+stubModule.exports = {
+  app: stubApp,
+  BrowserWindow: stubBrowserWindow,
+  ipcMain: stubIpcMain,
+  shell: stubShell,
+  dialog: stubDialog,
+  Notification: StubNotification,
+};
+require.cache[electronPath] = stubModule;
+
+const mainPath = path.resolve(__dirname, "..", "..", "src", "main.js");
+
+// Drop any prior load so re-requiring picks up the stub.
+delete require.cache[mainPath];
+
+module.exports = require(mainPath);

--- a/desktop/test/main/_loader.js
+++ b/desktop/test/main/_loader.js
@@ -19,7 +19,12 @@
 const path = require("path");
 const Module = require("module");
 
-const electronPath = require.resolve("electron");
+const electronPath = path.join(__dirname, "__electron_stub__.js");
+const originalResolveFilename = Module._resolveFilename;
+Module._resolveFilename = function resolveElectronStub(request, parent, isMain, options) {
+  if (request === "electron") return electronPath;
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
 
 const stubApp = {
   whenReady: () => new Promise(() => {}),

--- a/desktop/test/main/helpers.test.js
+++ b/desktop/test/main/helpers.test.js
@@ -1,0 +1,337 @@
+// Pure-helper unit tests for desktop/src/main.js.
+//
+// These exercise functions that have no project-state dependency (no
+// settings(), no projectRoot()). For helpers that DO touch project state
+// (listRuns, validationCommandForRun, nowRunId-shape) see the dedicated
+// test files in this directory.
+
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const main = require("./_loader.js");
+
+
+test("normalizeModelName aliases gpt-5.4-pro to gpt-5.5", () => {
+  assert.equal(main.normalizeModelName("gpt-5.4-pro"), "gpt-5.5");
+});
+
+test("normalizeModelName trims whitespace", () => {
+  assert.equal(main.normalizeModelName("  gpt-5.4-mini  "), "gpt-5.4-mini");
+});
+
+test("normalizeModelName passes through unknown values", () => {
+  assert.equal(main.normalizeModelName("custom-model"), "custom-model");
+});
+
+test("normalizeModelName handles null/undefined", () => {
+  assert.equal(main.normalizeModelName(null), "");
+  assert.equal(main.normalizeModelName(undefined), "");
+  assert.equal(main.normalizeModelName(""), "");
+});
+
+
+test("allowedModelSet always contains the three built-in models", () => {
+  const allowed = main.allowedModelSet({ modelCatalog: [] });
+  assert.ok(allowed.has("gpt-5.4-mini"));
+  assert.ok(allowed.has("gpt-5.4"));
+  assert.ok(allowed.has("gpt-5.5"));
+});
+
+test("allowedModelSet adds enabled catalog entries", () => {
+  const allowed = main.allowedModelSet({
+    modelCatalog: [
+      { model: "custom-a", enabled: true },
+      { model: "custom-b", enabled: false },
+      { model: "  custom-c  ", enabled: true },
+    ],
+  });
+  assert.ok(allowed.has("custom-a"));
+  assert.ok(!allowed.has("custom-b"), "disabled entries must be skipped");
+  assert.ok(allowed.has("custom-c"), "trimmed model names should be added");
+});
+
+test("allowedModelSet falls back to DEFAULT_SETTINGS catalog when input is empty", () => {
+  const allowed = main.allowedModelSet({ modelCatalog: [] });
+  // Built-in default catalog includes gpt-5.4-mini / gpt-5.4 / gpt-5.5 already.
+  assert.ok(allowed.has("gpt-5.4-mini"));
+  assert.ok(allowed.has("gpt-5.4"));
+});
+
+
+test("attachmentKind classifies common image extensions", () => {
+  for (const file of ["a.png", "b.JPG", "c.jpeg", "d.gif", "e.webp", "f.bmp", "g.ico"]) {
+    assert.equal(main.attachmentKind(file), "image", file);
+  }
+});
+
+test("attachmentKind classifies office documents", () => {
+  for (const file of ["doc.pdf", "x.docx", "y.xlsx", "z.pptx"]) {
+    assert.equal(main.attachmentKind(file), "document", file);
+  }
+});
+
+test("attachmentKind classifies archives", () => {
+  for (const file of ["pkg.zip", "src.tar", "blob.gz", "snap.7z", "log.rar"]) {
+    assert.equal(main.attachmentKind(file), "archive", file);
+  }
+});
+
+test("attachmentKind falls back to file for unknown extensions", () => {
+  assert.equal(main.attachmentKind("readme.md"), "file");
+  assert.equal(main.attachmentKind("noext"), "file");
+});
+
+
+test("isReadableTextAttachment recognizes common code/text extensions", () => {
+  for (const ext of [".js", ".ts", ".md", ".json", ".py", ".html", ".yaml", ".sql"]) {
+    assert.equal(main.isReadableTextAttachment(`file${ext}`), true, ext);
+  }
+});
+
+test("isReadableTextAttachment rejects images and binaries", () => {
+  for (const ext of [".png", ".pdf", ".zip", ".docx", ".bin", ".exe"]) {
+    assert.equal(main.isReadableTextAttachment(`file${ext}`), false, ext);
+  }
+});
+
+
+test("normalizeRel converts platform separators to forward slashes", () => {
+  assert.equal(main.normalizeRel("a/b/c"), "a/b/c");
+  // Use path.sep replacement explicitly so the test is portable.
+  const path = require("node:path");
+  const sample = ["a", "b", "c"].join(path.sep);
+  assert.equal(main.normalizeRel(sample), "a/b/c");
+});
+
+
+test("isSnapshotIgnored matches well-known directories", () => {
+  for (const rel of ["node_modules/foo.js", ".git/HEAD", "dist/index.js", "build/out.js", "__pycache__/x.py"]) {
+    assert.equal(main.isSnapshotIgnored(rel), true, rel);
+  }
+});
+
+test("isSnapshotIgnored matches well-known runtime paths", () => {
+  for (const rel of [".ai/runs/123/audit.json", ".ai/desktop/settings.json", ".ai/budget/ledger.jsonl"]) {
+    assert.equal(main.isSnapshotIgnored(rel), true, rel);
+  }
+});
+
+test("isSnapshotIgnored matches log/tmp/bak extensions", () => {
+  for (const rel of ["a.log", "b.tmp", "c.bak"]) {
+    assert.equal(main.isSnapshotIgnored(rel), true, rel);
+  }
+});
+
+test("isSnapshotIgnored does NOT match ordinary source files", () => {
+  for (const rel of ["src/index.js", "README.md", "package.json", "tests/foo.test.js"]) {
+    assert.equal(main.isSnapshotIgnored(rel), false, rel);
+  }
+});
+
+test("isSnapshotIgnored handles empty/whitespace input", () => {
+  assert.equal(main.isSnapshotIgnored(""), false);
+  assert.equal(main.isSnapshotIgnored("/"), false);
+});
+
+
+test("modelContextLimit returns 1M+ for gpt-4.1", () => {
+  assert.equal(main.modelContextLimit("gpt-4.1-mini"), 1047576);
+});
+
+test("modelContextLimit returns 128k for gpt-5 family", () => {
+  assert.equal(main.modelContextLimit("gpt-5.4-mini"), 128000);
+  assert.equal(main.modelContextLimit("gpt-5.5"), 128000);
+});
+
+test("modelContextLimit returns 128k default for unknown models", () => {
+  assert.equal(main.modelContextLimit("anthropic-claude"), 128000);
+  assert.equal(main.modelContextLimit(""), 128000);
+});
+
+
+test("modelTokenPrices returns the gpt-5.4-mini row", () => {
+  const prices = main.modelTokenPrices("gpt-5.4-mini");
+  assert.ok(prices);
+  assert.equal(prices.input, 0.75);
+  assert.equal(prices.output, 4.5);
+});
+
+test("modelTokenPrices returns the gpt-5.4 row", () => {
+  const prices = main.modelTokenPrices("gpt-5.4");
+  assert.ok(prices);
+  assert.equal(prices.input, 2.5);
+  assert.equal(prices.output, 15);
+});
+
+test("modelTokenPrices uses longest-prefix match (mini before main)", () => {
+  // 'gpt-5.4-mini' is more specific than 'gpt-5.4'; ensure a model name that
+  // contains both substrings hits the more specific one.
+  const prices = main.modelTokenPrices("custom-gpt-5.4-mini-experimental");
+  assert.ok(prices);
+  assert.equal(prices.input, 0.75, "should match gpt-5.4-mini, not gpt-5.4");
+});
+
+test("modelTokenPrices returns null for unknown models", () => {
+  assert.equal(main.modelTokenPrices("anthropic-claude"), null);
+  assert.equal(main.modelTokenPrices(""), null);
+});
+
+
+test("tokenCost returns zero estimate for unknown models", () => {
+  const result = main.tokenCost("anthropic-claude", 1000, 500, "estimate");
+  assert.equal(result.estimated_usd, 0);
+  assert.equal(result.actual_usd, null);
+  assert.equal(result.source, "no_model_price");
+});
+
+test("tokenCost computes estimate from per-1M rates", () => {
+  // gpt-5.4-mini: input 0.75/1M, output 4.5/1M. Use 200k tokens each (< 272k
+  // long-context threshold) so we get the plain rate with no multiplier.
+  const result = main.tokenCost("gpt-5.4-mini", 200_000, 200_000, "estimate");
+  // (200_000 * 0.75 + 200_000 * 4.5) / 1_000_000 = 1.05.
+  assert.equal(result.estimated_usd, 1.05);
+  assert.equal(result.confidence, "medium");
+  assert.equal(result.actual_usd, null, "estimate source -> null actual_usd");
+  assert.equal(result.source, "token_price_estimate");
+});
+
+test("tokenCost reports actual_usd when source is codex_cli", () => {
+  const result = main.tokenCost("gpt-5.4-mini", 100_000, 50_000, "codex_cli");
+  assert.notEqual(result.actual_usd, null);
+  assert.equal(result.source, "codex_cli_tokens_x_configured_price");
+  assert.equal(result.confidence, "high");
+});
+
+test("tokenCost applies long-context multiplier above 272k tokens for gpt-5.4", () => {
+  // gpt-5.4 has the long-context multiplier: input 2x, output 1.5x.
+  const short = main.tokenCost("gpt-5.4", 100_000, 100_000, "estimate");
+  const long = main.tokenCost("gpt-5.4", 300_000, 300_000, "estimate");
+  // Long-context input multiplier alone makes the long estimate larger per
+  // token. Compare per-token cost.
+  const shortPerToken = short.estimated_usd / 200_000;
+  const longPerToken = long.estimated_usd / 600_000;
+  assert.ok(longPerToken > shortPerToken, "long-context multiplier increases per-token cost");
+  assert.equal(long.long_context_multiplier.input, 2);
+  assert.equal(long.long_context_multiplier.output, 1.5);
+});
+
+
+test("extractCliTokenUsage falls back to estimate when no usage lines present", () => {
+  const usage = main.extractCliTokenUsage("hello world", "");
+  assert.equal(usage.source, "estimate");
+  assert.equal(usage.input, undefined);
+  assert.equal(usage.output, undefined);
+});
+
+test("extractCliTokenUsage parses input/output/total from stdout", () => {
+  const stdout = "input tokens: 1,234\noutput tokens: 567\ntotal tokens: 1801";
+  const usage = main.extractCliTokenUsage(stdout, "");
+  assert.equal(usage.source, "codex_cli");
+  assert.equal(usage.input, 1234);
+  assert.equal(usage.output, 567);
+  assert.equal(usage.total, 1801);
+});
+
+test("extractCliTokenUsage parses prompt/completion synonyms", () => {
+  const stdout = "prompt tokens 250\ncompletion tokens 100";
+  const usage = main.extractCliTokenUsage(stdout, "");
+  assert.equal(usage.input, 250);
+  assert.equal(usage.output, 100);
+});
+
+test("extractCliTokenUsage searches stderr too", () => {
+  const usage = main.extractCliTokenUsage("", "input tokens: 99");
+  assert.equal(usage.input, 99);
+  assert.equal(usage.source, "codex_cli");
+});
+
+
+test("formatArg leaves simple identifiers alone", () => {
+  assert.equal(main.formatArg("foo.py"), "foo.py");
+  assert.equal(main.formatArg("a-b_c"), "a-b_c");
+});
+
+test("formatArg quotes paths containing spaces", () => {
+  assert.equal(main.formatArg("path with spaces.py"), '"path with spaces.py"');
+});
+
+test("formatArg escapes embedded double quotes", () => {
+  assert.equal(main.formatArg('odd"name.py'), '"odd\\"name.py"');
+});
+
+test("formatArg quotes paths containing shell-meaningful punctuation", () => {
+  // Per the regex /\s|[{}":,]/, braces/colons/commas trigger quoting. This
+  // protects against accidental shell parsing for argument-style values.
+  assert.equal(main.formatArg("a:b"), '"a:b"');
+  assert.equal(main.formatArg("a,b"), '"a,b"');
+  assert.equal(main.formatArg("{x}"), '"{x}"');
+});
+
+
+test("needsShell only flags .cmd/.bat on Windows", () => {
+  if (process.platform === "win32") {
+    assert.equal(main.needsShell("npm.cmd"), true);
+    assert.equal(main.needsShell("foo.bat"), true);
+    assert.equal(main.needsShell("python.exe"), false);
+    assert.equal(main.needsShell("/usr/bin/python"), false);
+  } else {
+    assert.equal(main.needsShell("npm.cmd"), false);
+    assert.equal(main.needsShell("foo.bat"), false);
+  }
+});
+
+test("needsShell handles non-string inputs", () => {
+  assert.equal(main.needsShell(null), false);
+  assert.equal(main.needsShell(undefined), false);
+});
+
+
+test("providerForModel returns lowercase provider for matching catalog entry", () => {
+  const merged = {
+    modelCatalog: [
+      { model: "gpt-5.4-mini", provider: "OpenAI" },
+      { model: "local-llama", provider: "LM-Studio" },
+    ],
+  };
+  assert.equal(main.providerForModel(merged, "gpt-5.4-mini"), "openai");
+  assert.equal(main.providerForModel(merged, "local-llama"), "lm-studio");
+});
+
+test("providerForModel returns empty string when no match", () => {
+  assert.equal(main.providerForModel({ modelCatalog: [] }, "anything"), "");
+  assert.equal(main.providerForModel({}, "anything"), "");
+});
+
+
+test("providerBaseUrl returns lmstudio default when provider is lmstudio", () => {
+  const url = main.providerBaseUrl({ auth: {} }, "lmstudio");
+  assert.equal(url, "http://127.0.0.1:1234/v1");
+});
+
+test("providerBaseUrl honors auth.lmStudioUrl when set", () => {
+  const url = main.providerBaseUrl({ auth: { lmStudioUrl: "http://lan-host:1234/v1" } }, "lmstudio");
+  assert.equal(url, "http://lan-host:1234/v1");
+});
+
+test("providerBaseUrl returns auth.localModelUrl for local provider", () => {
+  const url = main.providerBaseUrl({ auth: { localModelUrl: "http://127.0.0.1:11434/v1" } }, "local");
+  assert.equal(url, "http://127.0.0.1:11434/v1");
+});
+
+test("providerBaseUrl returns empty string for unrecognised provider", () => {
+  assert.equal(main.providerBaseUrl({ auth: {} }, "openai"), "");
+  assert.equal(main.providerBaseUrl({ auth: {} }, ""), "");
+});
+
+
+test("commandExists returns false for an obviously bogus name", () => {
+  // "definitely-not-a-real-tool-xyz123" must not exist on PATH.
+  assert.equal(main.commandExists("definitely-not-a-real-tool-xyz123"), false);
+});
+
+test("commandExists returns false for empty input", () => {
+  assert.equal(main.commandExists(""), false);
+  assert.equal(main.commandExists(null), false);
+});

--- a/desktop/test/main/run-id.test.js
+++ b/desktop/test/main/run-id.test.js
@@ -1,0 +1,99 @@
+// Tests for nowRunId / runSortKeys / runMtime.
+
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const main = require("./_loader.js");
+
+
+test("nowRunId returns a deterministic shape", () => {
+  const id = main.nowRunId();
+  // Format: YYYYMMDD-HHMMSS-mmm-{hex6}, e.g. 20260426-093014-217-aabbcc.
+  assert.match(id, /^\d{8}-\d{6}-\d{3}-[0-9a-f]{6}$/);
+});
+
+test("nowRunId includes a prefix when provided", () => {
+  const id = main.nowRunId("undo");
+  assert.match(id, /^\d{8}-\d{6}-\d{3}-undo-[0-9a-f]{6}$/);
+});
+
+test("nowRunId emits unique values when called in succession", () => {
+  const ids = new Set();
+  for (let i = 0; i < 100; i += 1) {
+    ids.add(main.nowRunId());
+  }
+  // All 100 calls share at most 3-char ms field; the random hex suffix must
+  // make every call unique.
+  assert.equal(ids.size, 100, "every nowRunId() call should be unique");
+});
+
+test("nowRunId ms field is zero-padded to 3 chars", () => {
+  // Generate enough samples to be reasonably confident the ms field is always
+  // 3 chars (e.g. 001 not 1).
+  for (let i = 0; i < 50; i += 1) {
+    const id = main.nowRunId();
+    const parts = id.split("-");
+    assert.equal(parts[2].length, 3, `ms field must be 3 chars: got ${id}`);
+  }
+});
+
+
+test("runSortKeys returns ms timestamp for valid contract.created_at", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "main-tests-runSortKeys-"));
+  try {
+    const expected = Date.parse("2026-04-26T10:00:00Z");
+    const key = main.runSortKeys(tmp, { created_at: "2026-04-26T10:00:00Z" });
+    assert.equal(key, expected);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("runSortKeys falls back to directory mtime when contract.created_at is missing", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "main-tests-runSortKeys-"));
+  try {
+    const expected = fs.statSync(tmp).mtimeMs;
+    const key = main.runSortKeys(tmp, {});
+    assert.equal(key, expected);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("runSortKeys falls back to mtime when contract.created_at is invalid", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "main-tests-runSortKeys-"));
+  try {
+    const expected = fs.statSync(tmp).mtimeMs;
+    const key = main.runSortKeys(tmp, { created_at: "not-a-date" });
+    assert.equal(key, expected);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("runSortKeys returns 0 when both inputs are missing and dir does not exist", () => {
+  const missing = path.join(os.tmpdir(), `nope-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const key = main.runSortKeys(missing, null);
+  assert.equal(key, 0);
+});
+
+
+test("runMtime reflects actual directory mtime", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "main-tests-runMtime-"));
+  try {
+    const expected = fs.statSync(tmp).mtimeMs;
+    assert.equal(main.runMtime(tmp), expected);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("runMtime returns 0 for a missing path", () => {
+  const missing = path.join(os.tmpdir(), `nope-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  assert.equal(main.runMtime(missing), 0);
+});

--- a/desktop/test/main/run-listing.test.js
+++ b/desktop/test/main/run-listing.test.js
@@ -1,0 +1,193 @@
+// Integration tests for listRuns() ordering.
+//
+// listRuns reads runs from `<projectRoot>/.ai/runs/`. We point projectRoot at a
+// temp fixture dir by writing the desktop settings.json before each test, then
+// clean up. The settings.json path lives under `.ai/desktop/` which is
+// gitignored at the repo root, so this never touches tracked files.
+
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const main = require("./_loader.js");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SETTINGS_FILE = path.join(REPO_ROOT, ".ai", "desktop", "settings.json");
+const SETTINGS_BACKUP = `${SETTINGS_FILE}.test-backup`;
+
+
+function backupSettings() {
+  if (fs.existsSync(SETTINGS_FILE) && !fs.existsSync(SETTINGS_BACKUP)) {
+    fs.copyFileSync(SETTINGS_FILE, SETTINGS_BACKUP);
+  }
+}
+
+function restoreSettings() {
+  if (fs.existsSync(SETTINGS_BACKUP)) {
+    fs.copyFileSync(SETTINGS_BACKUP, SETTINGS_FILE);
+    fs.unlinkSync(SETTINGS_BACKUP);
+  } else if (fs.existsSync(SETTINGS_FILE)) {
+    // No prior settings.json existed; remove the one we created.
+    fs.unlinkSync(SETTINGS_FILE);
+  }
+}
+
+function pointSettingsAt(projectRoot) {
+  fs.mkdirSync(path.dirname(SETTINGS_FILE), { recursive: true });
+  fs.writeFileSync(
+    SETTINGS_FILE,
+    JSON.stringify({ projectRoot }, null, 2) + "\n",
+    "utf8",
+  );
+}
+
+function writeRun(runsDir, runId, { contractCreatedAt, taskType = "general", reasoning = "low", status = "ok", model = "gpt-5.4-mini" } = {}) {
+  const runDir = path.join(runsDir, runId);
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(runDir, "contract.json"),
+    JSON.stringify({
+      created_at: contractCreatedAt,
+      classification: { task_type: taskType, reasoning },
+      model,
+    }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(runDir, "audit.json"),
+    JSON.stringify({ status }),
+    "utf8",
+  );
+  fs.writeFileSync(path.join(runDir, "request.md"), `request body for ${runId}`, "utf8");
+  return runDir;
+}
+
+function makeFixture() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "main-tests-listRuns-"));
+  fs.mkdirSync(path.join(tmp, ".ai", "runs"), { recursive: true });
+  return tmp;
+}
+
+
+test("listRuns sorts newer contract.created_at first", (t) => {
+  backupSettings();
+  const fixture = makeFixture();
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const runsDir = path.join(fixture, ".ai", "runs");
+  writeRun(runsDir, "20260101-100000-001-aaaaaa", { contractCreatedAt: "2026-01-01T10:00:00Z" });
+  writeRun(runsDir, "20260301-100000-001-bbbbbb", { contractCreatedAt: "2026-03-01T10:00:00Z" });
+  writeRun(runsDir, "20260201-100000-001-cccccc", { contractCreatedAt: "2026-02-01T10:00:00Z" });
+
+  const runs = main.listRuns();
+  const ids = runs.map((r) => r.id);
+  assert.deepEqual(ids, [
+    "20260301-100000-001-bbbbbb",
+    "20260201-100000-001-cccccc",
+    "20260101-100000-001-aaaaaa",
+  ]);
+});
+
+test("listRuns surfaces taskType / reasoning / model from contract", (t) => {
+  backupSettings();
+  const fixture = makeFixture();
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const runsDir = path.join(fixture, ".ai", "runs");
+  writeRun(runsDir, "20260301-100000-001-bbbbbb", {
+    contractCreatedAt: "2026-03-01T10:00:00Z",
+    taskType: "ui",
+    reasoning: "medium",
+    model: "gpt-5.5",
+    status: "completed",
+  });
+
+  const runs = main.listRuns();
+  assert.equal(runs.length, 1);
+  const [run] = runs;
+  assert.equal(run.taskType, "ui");
+  assert.equal(run.reasoning, "medium");
+  assert.equal(run.model, "gpt-5.5");
+  assert.equal(run.status, "completed");
+});
+
+test("listRuns falls back to dir mtime when contract has no created_at", (t) => {
+  backupSettings();
+  const fixture = makeFixture();
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const runsDir = path.join(fixture, ".ai", "runs");
+  const dir1 = writeRun(runsDir, "20260101-100000-001-aaaaaa", { contractCreatedAt: undefined });
+  const dir2 = writeRun(runsDir, "20260201-100000-001-bbbbbb", { contractCreatedAt: undefined });
+
+  // Force dir1 mtime older, dir2 mtime newer.
+  const now = Date.now();
+  fs.utimesSync(dir1, new Date(now - 60_000), new Date(now - 60_000));
+  fs.utimesSync(dir2, new Date(now), new Date(now));
+
+  const runs = main.listRuns();
+  const ids = runs.map((r) => r.id);
+  assert.deepEqual(ids, [
+    "20260201-100000-001-bbbbbb",
+    "20260101-100000-001-aaaaaa",
+  ]);
+});
+
+test("listRuns ties broken deterministically by run id descending", (t) => {
+  backupSettings();
+  const fixture = makeFixture();
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const runsDir = path.join(fixture, ".ai", "runs");
+  // All three share the same created_at AND we'll force the same mtime, so the
+  // tie-breaker (id descending via localeCompare) decides.
+  const ts = "2026-04-26T10:00:00Z";
+  const dir1 = writeRun(runsDir, "20260426-100000-001-aaaaaa", { contractCreatedAt: ts });
+  const dir2 = writeRun(runsDir, "20260426-100000-001-bbbbbb", { contractCreatedAt: ts });
+  const dir3 = writeRun(runsDir, "20260426-100000-001-cccccc", { contractCreatedAt: ts });
+  const fixedMtime = new Date("2026-04-26T10:00:00Z");
+  fs.utimesSync(dir1, fixedMtime, fixedMtime);
+  fs.utimesSync(dir2, fixedMtime, fixedMtime);
+  fs.utimesSync(dir3, fixedMtime, fixedMtime);
+
+  const runs = main.listRuns();
+  const ids = runs.map((r) => r.id);
+  assert.deepEqual(ids, [
+    "20260426-100000-001-cccccc",
+    "20260426-100000-001-bbbbbb",
+    "20260426-100000-001-aaaaaa",
+  ]);
+});
+
+test("listRuns returns empty array when runs dir is missing", (t) => {
+  backupSettings();
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "main-tests-listRuns-empty-"));
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const runs = main.listRuns();
+  assert.deepEqual(runs, []);
+});

--- a/desktop/test/main/validation-command.test.js
+++ b/desktop/test/main/validation-command.test.js
@@ -1,0 +1,211 @@
+// Tests for validationCommandForRun argv shape.
+//
+// These tests pin down the validation-command selection logic: explicit
+// override from .ai/config/project.json, language-aware default, npm-script
+// fallback. They also assert that python file paths get passed through
+// formatArg, which is the core protection added by issue #5.
+
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const main = require("./_loader.js");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SETTINGS_FILE = path.join(REPO_ROOT, ".ai", "desktop", "settings.json");
+const SETTINGS_BACKUP = `${SETTINGS_FILE}.test-backup`;
+
+
+function backupSettings() {
+  if (fs.existsSync(SETTINGS_FILE) && !fs.existsSync(SETTINGS_BACKUP)) {
+    fs.copyFileSync(SETTINGS_FILE, SETTINGS_BACKUP);
+  }
+}
+
+function restoreSettings() {
+  if (fs.existsSync(SETTINGS_BACKUP)) {
+    fs.copyFileSync(SETTINGS_BACKUP, SETTINGS_FILE);
+    fs.unlinkSync(SETTINGS_BACKUP);
+  } else if (fs.existsSync(SETTINGS_FILE)) {
+    fs.unlinkSync(SETTINGS_FILE);
+  }
+}
+
+function pointSettingsAt(projectRoot) {
+  fs.mkdirSync(path.dirname(SETTINGS_FILE), { recursive: true });
+  fs.writeFileSync(
+    SETTINGS_FILE,
+    JSON.stringify({ projectRoot }, null, 2) + "\n",
+    "utf8",
+  );
+}
+
+function makeFixture({ packageScripts = null, projectConfig = null, hasPytest = false } = {}) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "main-tests-validation-"));
+  if (packageScripts) {
+    fs.writeFileSync(
+      path.join(tmp, "package.json"),
+      JSON.stringify({ scripts: packageScripts }, null, 2),
+      "utf8",
+    );
+  }
+  if (hasPytest) {
+    fs.writeFileSync(path.join(tmp, "pytest.ini"), "[pytest]\n", "utf8");
+  }
+  if (projectConfig) {
+    fs.mkdirSync(path.join(tmp, ".ai", "config"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, ".ai", "config", "project.json"),
+      JSON.stringify(projectConfig, null, 2),
+      "utf8",
+    );
+  }
+  return tmp;
+}
+
+
+test("validationCommandForRun honors explicit project config validation.command", (t) => {
+  backupSettings();
+  const fixture = makeFixture({
+    packageScripts: { test: "vitest" },
+    projectConfig: { validation: { command: "make verify" } },
+  });
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const cmd = main.validationCommandForRun({ audit: { changed_files: ["src/app.js"] } });
+  assert.equal(cmd, "make verify");
+});
+
+test("validationCommandForRun picks `npm run check` when js changed and `check` script exists", (t) => {
+  backupSettings();
+  const fixture = makeFixture({ packageScripts: { check: "node --check src/main.js", test: "node --test" } });
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const cmd = main.validationCommandForRun({ audit: { changed_files: ["src/main.js"] } });
+  assert.equal(cmd, "npm run check");
+});
+
+test("validationCommandForRun picks `npm test` when js changed and only `test` script exists", (t) => {
+  backupSettings();
+  const fixture = makeFixture({ packageScripts: { test: "node --test" } });
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const cmd = main.validationCommandForRun({ audit: { changed_files: ["src/main.js"] } });
+  assert.equal(cmd, "npm test");
+});
+
+test("validationCommandForRun picks `npm run lint` when only `lint` script exists for js changes", (t) => {
+  backupSettings();
+  const fixture = makeFixture({ packageScripts: { lint: "eslint ." } });
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const cmd = main.validationCommandForRun({ audit: { changed_files: ["src/main.js"] } });
+  assert.equal(cmd, "npm run lint");
+});
+
+test("validationCommandForRun builds python -m py_compile for python changes only", (t) => {
+  backupSettings();
+  const fixture = makeFixture();
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const cmd = main.validationCommandForRun({ audit: { changed_files: ["aidev.py"] } });
+  assert.equal(cmd, "python -m py_compile aidev.py");
+});
+
+test("validationCommandForRun quotes python paths with spaces (no shell injection)", (t) => {
+  backupSettings();
+  const fixture = makeFixture();
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const cmd = main.validationCommandForRun({
+    audit: { changed_files: ["a/b c/script.py", "ok/path.py"] },
+  });
+  // formatArg quotes the spaced one and leaves the simple one alone.
+  assert.equal(cmd, 'python -m py_compile "a/b c/script.py" ok/path.py');
+});
+
+test("validationCommandForRun excludes non-py files from the py_compile arg list", (t) => {
+  backupSettings();
+  const fixture = makeFixture();
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const cmd = main.validationCommandForRun({
+    audit: { changed_files: ["a.py", "README.md", "b.py"] },
+  });
+  assert.equal(cmd, "python -m py_compile a.py b.py");
+});
+
+test("validationCommandForRun falls back to npm test/check when only non-code files changed", (t) => {
+  backupSettings();
+  const fixture = makeFixture({ packageScripts: { test: "vitest" } });
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const cmd = main.validationCommandForRun({ audit: { changed_files: ["README.md"] } });
+  assert.equal(cmd, "npm test");
+});
+
+test("validationCommandForRun returns empty string when nothing applies", (t) => {
+  backupSettings();
+  const fixture = makeFixture(); // no package.json, no pytest, no config.
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  const cmd = main.validationCommandForRun({ audit: { changed_files: ["README.md"] } });
+  assert.equal(cmd, "");
+});
+
+test("validationCommandForRun handles missing audit/changed_files gracefully", (t) => {
+  backupSettings();
+  const fixture = makeFixture({ packageScripts: { test: "vitest" } });
+  pointSettingsAt(fixture);
+  t.after(() => {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    restoreSettings();
+  });
+
+  // No audit at all.
+  assert.equal(main.validationCommandForRun({}), "npm test");
+  // changed_files missing.
+  assert.equal(main.validationCommandForRun({ audit: {} }), "npm test");
+  // changed_files not an array.
+  assert.equal(main.validationCommandForRun({ audit: { changed_files: null } }), "npm test");
+});

--- a/desktop/test/main/validation-command.test.js
+++ b/desktop/test/main/validation-command.test.js
@@ -19,6 +19,27 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const SETTINGS_FILE = path.join(REPO_ROOT, ".ai", "desktop", "settings.json");
 const SETTINGS_BACKUP = `${SETTINGS_FILE}.test-backup`;
 
+function assertShellCommand(actual, display) {
+  assert.equal(actual.display, display);
+  assert.equal(actual.argv, null);
+  assert.equal(actual.shellString, display);
+}
+
+function assertNpmCommand(actual, display, args) {
+  assert.equal(actual.display, display);
+  assert.ok(Array.isArray(actual.argv), "expected argv command");
+  assert.match(path.basename(actual.argv[0]), /^npm(\.cmd)?$/i);
+  assert.deepEqual(actual.argv.slice(1), args);
+  assert.equal(actual.shellString, null);
+}
+
+function assertPythonCommand(actual, display, args) {
+  assert.equal(actual.display, display);
+  assert.ok(Array.isArray(actual.argv), "expected argv command");
+  assert.match(path.basename(actual.argv[0]), /^python(3)?(\.exe)?$/i);
+  assert.deepEqual(actual.argv.slice(1), args);
+  assert.equal(actual.shellString, null);
+}
 
 function backupSettings() {
   if (fs.existsSync(SETTINGS_FILE) && !fs.existsSync(SETTINGS_BACKUP)) {
@@ -81,7 +102,7 @@ test("validationCommandForRun honors explicit project config validation.command"
   });
 
   const cmd = main.validationCommandForRun({ audit: { changed_files: ["src/app.js"] } });
-  assert.equal(cmd, "make verify");
+  assertShellCommand(cmd, "make verify");
 });
 
 test("validationCommandForRun picks `npm run check` when js changed and `check` script exists", (t) => {
@@ -94,7 +115,7 @@ test("validationCommandForRun picks `npm run check` when js changed and `check` 
   });
 
   const cmd = main.validationCommandForRun({ audit: { changed_files: ["src/main.js"] } });
-  assert.equal(cmd, "npm run check");
+  assertNpmCommand(cmd, "npm run check", ["run", "check"]);
 });
 
 test("validationCommandForRun picks `npm test` when js changed and only `test` script exists", (t) => {
@@ -107,7 +128,7 @@ test("validationCommandForRun picks `npm test` when js changed and only `test` s
   });
 
   const cmd = main.validationCommandForRun({ audit: { changed_files: ["src/main.js"] } });
-  assert.equal(cmd, "npm test");
+  assertNpmCommand(cmd, "npm test", ["test"]);
 });
 
 test("validationCommandForRun picks `npm run lint` when only `lint` script exists for js changes", (t) => {
@@ -120,7 +141,7 @@ test("validationCommandForRun picks `npm run lint` when only `lint` script exist
   });
 
   const cmd = main.validationCommandForRun({ audit: { changed_files: ["src/main.js"] } });
-  assert.equal(cmd, "npm run lint");
+  assertNpmCommand(cmd, "npm run lint", ["run", "lint"]);
 });
 
 test("validationCommandForRun builds python -m py_compile for python changes only", (t) => {
@@ -133,7 +154,7 @@ test("validationCommandForRun builds python -m py_compile for python changes onl
   });
 
   const cmd = main.validationCommandForRun({ audit: { changed_files: ["aidev.py"] } });
-  assert.equal(cmd, "python -m py_compile aidev.py");
+  assertPythonCommand(cmd, "python -m py_compile aidev.py", ["-m", "py_compile", "aidev.py"]);
 });
 
 test("validationCommandForRun quotes python paths with spaces (no shell injection)", (t) => {
@@ -149,7 +170,11 @@ test("validationCommandForRun quotes python paths with spaces (no shell injectio
     audit: { changed_files: ["a/b c/script.py", "ok/path.py"] },
   });
   // formatArg quotes the spaced one and leaves the simple one alone.
-  assert.equal(cmd, 'python -m py_compile "a/b c/script.py" ok/path.py');
+  assertPythonCommand(
+    cmd,
+    'python -m py_compile "a/b c/script.py" ok/path.py',
+    ["-m", "py_compile", "a/b c/script.py", "ok/path.py"],
+  );
 });
 
 test("validationCommandForRun excludes non-py files from the py_compile arg list", (t) => {
@@ -164,7 +189,7 @@ test("validationCommandForRun excludes non-py files from the py_compile arg list
   const cmd = main.validationCommandForRun({
     audit: { changed_files: ["a.py", "README.md", "b.py"] },
   });
-  assert.equal(cmd, "python -m py_compile a.py b.py");
+  assertPythonCommand(cmd, "python -m py_compile a.py b.py", ["-m", "py_compile", "a.py", "b.py"]);
 });
 
 test("validationCommandForRun falls back to npm test/check when only non-code files changed", (t) => {
@@ -177,7 +202,7 @@ test("validationCommandForRun falls back to npm test/check when only non-code fi
   });
 
   const cmd = main.validationCommandForRun({ audit: { changed_files: ["README.md"] } });
-  assert.equal(cmd, "npm test");
+  assertNpmCommand(cmd, "npm test", ["test"]);
 });
 
 test("validationCommandForRun returns empty string when nothing applies", (t) => {
@@ -190,7 +215,7 @@ test("validationCommandForRun returns empty string when nothing applies", (t) =>
   });
 
   const cmd = main.validationCommandForRun({ audit: { changed_files: ["README.md"] } });
-  assert.equal(cmd, "");
+  assert.equal(cmd, null);
 });
 
 test("validationCommandForRun handles missing audit/changed_files gracefully", (t) => {
@@ -203,9 +228,9 @@ test("validationCommandForRun handles missing audit/changed_files gracefully", (
   });
 
   // No audit at all.
-  assert.equal(main.validationCommandForRun({}), "npm test");
+  assertNpmCommand(main.validationCommandForRun({}), "npm test", ["test"]);
   // changed_files missing.
-  assert.equal(main.validationCommandForRun({ audit: {} }), "npm test");
+  assertNpmCommand(main.validationCommandForRun({ audit: {} }), "npm test", ["test"]);
   // changed_files not an array.
-  assert.equal(main.validationCommandForRun({ audit: { changed_files: null } }), "npm test");
+  assertNpmCommand(main.validationCommandForRun({ audit: { changed_files: null } }), "npm test", ["test"]);
 });


### PR DESCRIPTION
## Summary

Adds 73 `node:test` unit tests under `desktop/test/main/` covering the helpers called out in issue #13 plus a wider set of pure helpers that were trivial to lock in alongside.

Closes #13.

## What is tested

- `normalizeModelName`, `allowedModelSet` — alias normalization and catalog membership.
- `attachmentKind`, `isReadableTextAttachment` — extension-driven classification of attachments.
- `normalizeRel`, `isSnapshotIgnored` — path policy used by snapshot/run handling.
- `modelContextLimit`, `modelTokenPrices`, `tokenCost` — including the `>272k` long-context multiplier on `gpt-5.4*`.
- `extractCliTokenUsage` — parses `input/output/total` from codex stdout/stderr; falls back to estimate.
- `formatArg` — quoting for spaces and shell-meaningful punctuation; embedded `\"` escaping.
- `needsShell` — Windows `.cmd`/`.bat` detection only.
- `providerForModel`, `providerBaseUrl` — catalog lookup + LM Studio / local-model URL resolution.
- `commandExists` — returns false for bogus names / empty input (deterministic; doesn't depend on PATH).
- `nowRunId` — shape `YYYYMMDD-HHMMSS-mmm-{hex6}`, prefix variant (`...-undo-{hex6}`), uniqueness across 100 calls, zero-padded ms field.
- `runSortKeys`, `runMtime` — `created_at` primary, dir mtime fallback, returns 0 when missing.
- `listRuns` — ordering by `created_at` desc, mtime fallback, id-descending tie-breaker, empty array when runs dir missing, surfaces `taskType`/`reasoning`/`model`/`status` from contract+audit.
- `validationCommandForRun` — explicit `validation.command` override from `.ai/config/project.json`, npm script selection per extension (`check`/`test`/`lint`), `python -m py_compile` arg list with `formatArg` quoting (key safety: `\"a/b c/script.py\"`), fallback to `npm test`/`npm run check`, empty string when nothing applies, graceful handling of missing/null `audit.changed_files`.

## How tests reach the helpers (`module.exports` block)

`desktop/src/main.js` requires `electron` at the top and registers ~100 `ipcMain.handle(...)` listeners plus `app.whenReady().then(createWindow)` at module load. To avoid a refactor (electron lane is actively working on this file), this PR appends a single trailing `module.exports = { ... }` block listing only the helpers the tests call.

- Zero behavior change. Electron's main entry point does not read its own module exports.
- The export block is the only edit to `main.js` and lives at the bottom, far from the function bodies the electron lane is editing in #3/#6/#4/#9.
- A larger extract-to-`main-helpers.js` refactor is a worthwhile follow-up after the electron lane drains, but is intentionally out of scope here.

## Loader (`desktop/test/main/_loader.js`)

Pre-populates `require.cache[require.resolve(\"electron\")]` with no-op stubs (`app.whenReady` returns a never-resolving Promise so `createWindow` never fires; `BrowserWindow` is a constructor stub; `ipcMain.handle`/`shell`/`dialog`/`Notification` are noop). Tests `require(\"./_loader.js\")` which transitively loads the real `main.js` against the stub and re-exports its module.exports.

## Test execution

`npm run test:main` (added in this PR) runs:

```
node --test --test-concurrency=1 \"test/main/*.test.js\"
```

`--test-concurrency=1` is required because `run-listing.test.js` and `validation-command.test.js` share a single settings file (`<repo>/.ai/desktop/settings.json`) to redirect `projectRoot()` at a per-test tmp fixture directory. The path is gitignored so the tests never touch tracked files; each integration test backs up the existing settings.json and restores it in `t.after()`.

## Test plan

- [ ] `cd desktop && npm install` (one-time, dev only)
- [ ] `cd desktop && npm run check` — Node syntax check on main + preload + renderer (must still pass with the new export block)
- [ ] `cd desktop && npm run smoke` — existing string-grep smoke must still pass (\"Smoke checks passed.\")
- [ ] `cd desktop && npm run test:main` — 73 passed in ~0.6s
- [ ] Manual sanity: launch the desktop app via `npm start` and verify the sidebar still loads (the `module.exports` block must not have changed runtime behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)