### PR TITLE
Extract shared budget defaults to JSON (JS side, #9)

### DIFF
--- a/desktop/src/policy.js
+++ b/desktop/src/policy.js
@@ -1,30 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const DEFAULT_BUDGET = {
-  session_budget_usd: 5.0,
-  request_budget_usd: 0.5,
-  retry_budget_usd: 0.15,
-  max_codex_calls_per_request: 2,
-  daily_codex_call_limit: 20,
-  daily_high_call_limit: 3,
-  daily_xhigh_call_limit: 1,
-  warn_at_percent: 80,
-  block_at_percent: 95,
-  estimated_call_cost_usd: {
-    none: 0.01,
-    low: 0.03,
-    medium: 0.08,
-    high: 0.25,
-    xhigh: 0.6,
-  },
-  model_token_prices_usd_per_1m: {
-    "gpt-5.4-mini": { input: 0.75, cached_input: 0.075, output: 4.5 },
-    "gpt-5.4": { input: 2.5, cached_input: 0.25, output: 15.0 },
-    "gpt-5.5": { input: 2.5, cached_input: 0.25, output: 15.0 },
-    "gpt-5.4-nano": { input: 0.2, cached_input: 0.02, output: 1.25 },
-  },
-};
+const DEFAULT_BUDGET = require("../../shared/budget-defaults.json");
 
 const REQUIRES_APPROVAL = new Set(["high", "xhigh"]);
 

--- a/desktop/test/policy/budget-defaults-shape.test.js
+++ b/desktop/test/policy/budget-defaults-shape.test.js
@@ -1,0 +1,94 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const assert = require("node:assert/strict");
+
+const SHARED_FILE = path.resolve(__dirname, "..", "..", "..", "shared", "budget-defaults.json");
+
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`  FAIL  ${name}`);
+    console.error(err);
+  }
+}
+
+console.log("budget-defaults shared JSON:");
+
+test("file exists at the expected repo-root location", () => {
+  assert.ok(fs.existsSync(SHARED_FILE), `missing: ${SHARED_FILE}`);
+});
+
+test("parses as JSON without errors", () => {
+  JSON.parse(fs.readFileSync(SHARED_FILE, "utf8"));
+});
+
+test("policy.js loads the shared file as its DEFAULT_BUDGET", () => {
+  const fromPolicy = require("../../src/policy").DEFAULT_BUDGET;
+  const fromDisk = JSON.parse(fs.readFileSync(SHARED_FILE, "utf8"));
+  assert.deepEqual(fromPolicy, fromDisk, "policy.DEFAULT_BUDGET must equal the shared JSON contents");
+});
+
+test("has the required top-level keys", () => {
+  const cfg = require(SHARED_FILE);
+  const required = [
+    "session_budget_usd",
+    "request_budget_usd",
+    "retry_budget_usd",
+    "max_codex_calls_per_request",
+    "daily_codex_call_limit",
+    "daily_high_call_limit",
+    "daily_xhigh_call_limit",
+    "warn_at_percent",
+    "block_at_percent",
+    "estimated_call_cost_usd",
+    "model_token_prices_usd_per_1m",
+  ];
+  for (const key of required) {
+    assert.ok(Object.prototype.hasOwnProperty.call(cfg, key), `missing key: ${key}`);
+  }
+});
+
+test("session and request budgets are positive numbers", () => {
+  const cfg = require(SHARED_FILE);
+  assert.equal(typeof cfg.session_budget_usd, "number");
+  assert.ok(cfg.session_budget_usd > 0, "session cap must be > 0");
+  assert.equal(typeof cfg.request_budget_usd, "number");
+  assert.ok(cfg.request_budget_usd > 0, "request cap must be > 0");
+});
+
+test("warn_at_percent < block_at_percent and both are <= 100", () => {
+  const cfg = require(SHARED_FILE);
+  assert.ok(cfg.warn_at_percent < cfg.block_at_percent, "warn must come before block");
+  assert.ok(cfg.block_at_percent <= 100, "block_at_percent should be <= 100");
+});
+
+test("estimated_call_cost_usd has every reasoning tier", () => {
+  const cfg = require(SHARED_FILE);
+  for (const tier of ["none", "low", "medium", "high", "xhigh"]) {
+    assert.ok(typeof cfg.estimated_call_cost_usd[tier] === "number", `missing tier cost: ${tier}`);
+    assert.ok(cfg.estimated_call_cost_usd[tier] >= 0, `tier cost ${tier} must be >= 0`);
+  }
+});
+
+test("model_token_prices_usd_per_1m entries each have input + output rates", () => {
+  const cfg = require(SHARED_FILE);
+  const models = Object.keys(cfg.model_token_prices_usd_per_1m);
+  assert.ok(models.length > 0, "at least one model must be priced");
+  for (const model of models) {
+    const price = cfg.model_token_prices_usd_per_1m[model];
+    assert.equal(typeof price.input, "number", `${model}.input must be a number`);
+    assert.equal(typeof price.output, "number", `${model}.output must be a number`);
+    assert.ok(price.input >= 0, `${model}.input must be >= 0`);
+    assert.ok(price.output >= 0, `${model}.output must be >= 0`);
+  }
+});
+
+if (failed) {
+  console.error(`\n${failed} test(s) failed.`);
+  process.exit(1);
+}
+console.log("\nAll budget-defaults shape tests passed.");

--- a/desktop/test/smoke.js
+++ b/desktop/test/smoke.js
@@ -216,5 +216,6 @@ assert.ok(latestUsage.context.used_percent >= 0, "usage should record context fi
 assert.ok(latestUsage.cost.estimated_usd >= 0, "usage should record cost estimate");
 
 cp.execFileSync(process.execPath, [path.resolve(__dirname, "policy.test.js")], { stdio: "inherit" });
+cp.execFileSync(process.execPath, [path.resolve(__dirname, "policy", "budget-defaults-shape.test.js")], { stdio: "inherit" });
 
 console.log("Smoke checks passed.");

--- a/shared/budget-defaults.json
+++ b/shared/budget-defaults.json
@@ -1,0 +1,24 @@
+{
+  "session_budget_usd": 5.0,
+  "request_budget_usd": 0.5,
+  "retry_budget_usd": 0.15,
+  "max_codex_calls_per_request": 2,
+  "daily_codex_call_limit": 20,
+  "daily_high_call_limit": 3,
+  "daily_xhigh_call_limit": 1,
+  "warn_at_percent": 80,
+  "block_at_percent": 95,
+  "estimated_call_cost_usd": {
+    "none": 0.01,
+    "low": 0.03,
+    "medium": 0.08,
+    "high": 0.25,
+    "xhigh": 0.6
+  },
+  "model_token_prices_usd_per_1m": {
+    "gpt-5.4-mini": { "input": 0.75, "cached_input": 0.075, "output": 4.5, "source": "OpenAI model docs, checked 2026-04-26" },
+    "gpt-5.4": { "input": 2.5, "cached_input": 0.25, "output": 15.0, "source": "OpenAI model docs, checked 2026-04-26" },
+    "gpt-5.5": { "input": 2.5, "cached_input": 0.25, "output": 15.0, "source": "temporary GPT-5.4-compatible estimate until verified pricing is configured" },
+    "gpt-5.4-nano": { "input": 0.2, "cached_input": 0.02, "output": 1.25, "source": "OpenAI model docs, checked 2026-04-26" }
+  }
+}


### PR DESCRIPTION
> **Stacked on PR #24. Merge #24 first; this PR will auto-retarget to main once #24 lands.**

## Summary
- The `DEFAULT_BUDGET` literal currently lives in two places: `desktop/src/policy.js` (added in #3, currently in PR #24) and `aidev.py` (~line 90). Any change to budget caps, daily call limits, or model token prices has to be applied to both, which is exactly the drift hazard #9 flags.
- This PR adds `shared/budget-defaults.json` at the repo root as the single source of truth and switches `policy.js` to load it via `require("../../shared/budget-defaults.json")`. The JSON is the **superset** of both prior copies — it keeps the `source` strings that aidev.py's per-model entries carry, since policy.js silently ignores unknown fields and the backend follow-up will need them.
- The Python side is **intentionally untouched** here. Backend will land a matching `aidev.py` patch as a follow-up that flips the closing keyword to `Closes #9`. The brief-lived double-source state ends once both PRs merge.

## Test plan
- [x] `cd desktop && npm run check`
- [x] `cd desktop && npm run smoke` — existing 10 policy tests pass unchanged (notably `loadBudget merges defaults with on-disk values`, which exercises the new code path).
- [x] New `desktop/test/policy/budget-defaults-shape.test.js` (8 cases):
  - file exists at the expected repo-root location
  - parses as valid JSON
  - `policy.DEFAULT_BUDGET` equals the on-disk JSON byte-for-byte
  - every required top-level key is present
  - session and request caps are positive numbers
  - `warn_at_percent` < `block_at_percent` and both <= 100
  - `estimated_call_cost_usd` has every reasoning tier (none/low/medium/high/xhigh)
  - every priced model has positive input + output rates

## Why a stacked PR
`desktop/src/policy.js` only exists on the `fix/3-budget-direct-mode` branch (PR #24, not yet merged); it isn't on `main`. A clean dedupe diff requires basing on PR #24's tip. When #24 merges, GitHub will auto-retarget this PR's base to `main` and the diff will resolve to: `+shared/budget-defaults.json`, `+desktop/test/policy/...`, and the small `policy.js` literal-to-`require` swap.

Refs #9