### PR TITLE
Add filesystem safety tests for undo + drift (close #12)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -8,7 +8,8 @@
     "start": "electron .",
     "start:project": "electron . --project",
     "check": "node --check src/main.js && node --check src/preload.js && node --check src/renderer/app.js",
-    "smoke": "node test/smoke.js"
+    "smoke": "node test/smoke.js",
+    "test:fs-safety": "node --test --test-concurrency=1 \"test/fs-safety/*.test.js\""
   },
   "devDependencies": {
     "electron": "^39.2.6"

--- a/desktop/test/fs-safety/restore-run-extras.test.js
+++ b/desktop/test/fs-safety/restore-run-extras.test.js
@@ -1,0 +1,318 @@
+// Additional restoreRunFromDir tests, complementary to the home-rolled tests
+// already shipped in desktop/test/restore-run.test.js by PR #21.
+//
+// These exercise the resolveGit/hasGitRepository fallback path plus a few
+// edge cases that are not covered in the original file (fileHashOrNull
+// inputs, no-op runs, file-already-removed-by-user, identity-only changes).
+
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const cp = require("node:child_process");
+const crypto = require("node:crypto");
+
+const { restoreRunFromDir, fileHashOrNull } = require("../../src/restore-run");
+
+
+function sha256(buf) {
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+function makeWorld() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aidev-fs-safety-"));
+  const runDir = path.join(root, ".ai", "runs", "20260101-000000-000-test");
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.mkdirSync(path.join(runDir, "before-files"), { recursive: true });
+  return { root, runDir };
+}
+
+function writeFile(root, rel, contents) {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents);
+}
+
+function recordStates(runDir, before, after) {
+  fs.writeFileSync(
+    path.join(runDir, "before-state.json"),
+    JSON.stringify({ git: { has_git: false }, files: before }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(runDir, "after-state.json"),
+    JSON.stringify({ git: { has_git: false }, files: after }),
+    "utf8",
+  );
+}
+
+function cleanup(root) {
+  try {
+    fs.rmSync(root, { recursive: true, force: true });
+  } catch {}
+}
+
+
+// -- fileHashOrNull --------------------------------------------------------
+
+test("fileHashOrNull returns null for a missing path", () => {
+  const missing = path.join(os.tmpdir(), `nope-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  assert.equal(fileHashOrNull(missing), null);
+});
+
+test("fileHashOrNull returns null for a directory", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aidev-fhon-dir-"));
+  try {
+    assert.equal(fileHashOrNull(dir), null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("fileHashOrNull returns sha256 hex for a regular file", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aidev-fhon-file-"));
+  try {
+    const file = path.join(dir, "x.txt");
+    const content = Buffer.from("hello\n");
+    fs.writeFileSync(file, content);
+    assert.equal(fileHashOrNull(file), sha256(content));
+  } finally {
+    cleanup(dir);
+  }
+});
+
+
+// -- restoreRunFromDir: input validation -----------------------------------
+
+test("restoreRunFromDir reports run-not-found for a missing dir", () => {
+  const result = restoreRunFromDir(
+    path.join(os.tmpdir(), `does-not-exist-${Date.now()}`),
+    os.tmpdir(),
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.error, /Run not found/);
+});
+
+test("restoreRunFromDir refuses runs without an after-state file map (legacy guard)", (t) => {
+  const { root, runDir } = makeWorld();
+  t.after(() => cleanup(root));
+
+  // before-state has files but after-state lacks the `files` key entirely.
+  fs.writeFileSync(
+    path.join(runDir, "before-state.json"),
+    JSON.stringify({ files: {} }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(runDir, "after-state.json"),
+    JSON.stringify({ git: { has_git: false } }),
+    "utf8",
+  );
+  writeFile(root, "src/x.txt", Buffer.from("x"));
+
+  const result = restoreRunFromDir(runDir, root);
+  assert.equal(result.ok, false);
+  assert.match(result.error, /after-state file map/);
+  assert.equal(fs.existsSync(path.join(root, "src/x.txt")), true,
+    "file must NOT be deleted when after-state is incomplete");
+});
+
+test("restoreRunFromDir refuses runs whose after-state.files is not an object", (t) => {
+  const { root, runDir } = makeWorld();
+  t.after(() => cleanup(root));
+
+  fs.writeFileSync(
+    path.join(runDir, "before-state.json"),
+    JSON.stringify({ files: {} }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(runDir, "after-state.json"),
+    JSON.stringify({ files: "not an object" }),
+    "utf8",
+  );
+
+  const result = restoreRunFromDir(runDir, root);
+  assert.equal(result.ok, false);
+  assert.match(result.error, /after-state file map/);
+});
+
+
+// -- restoreRunFromDir: no-op cases ----------------------------------------
+
+test("identical before/after hashes report empty success without touching the workspace", (t) => {
+  const { root, runDir } = makeWorld();
+  t.after(() => cleanup(root));
+  const content = Buffer.from("unchanged\n");
+  writeFile(root, "src/static.txt", content);
+  recordStates(
+    runDir,
+    { "src/static.txt": sha256(content) },
+    { "src/static.txt": sha256(content) },
+  );
+
+  const result = restoreRunFromDir(runDir, root);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.restored, []);
+  assert.deepEqual(result.removed, []);
+  // Confirm we didn't accidentally touch it.
+  assert.equal(fs.readFileSync(path.join(root, "src/static.txt"), "utf8"), "unchanged\n");
+});
+
+test("a run-removed file (after-state hash null/missing) that is already gone is a no-op", (t) => {
+  const { root, runDir } = makeWorld();
+  t.after(() => cleanup(root));
+  // before had a file with hash X; after-state records an empty files map ->
+  // the file should be restored from before-files. But if before-files isn't
+  // present, the path falls through to git fallback (covered in the next
+  // section). Here we test only that an after-state recorded as `null` still
+  // works.
+  recordStates(
+    runDir,
+    {},
+    { "src/already-gone.txt": null },
+  );
+
+  const result = restoreRunFromDir(runDir, root);
+  // before doesn't have it, after recorded null -> not in tracked because
+  // beforeFiles[rel] (undefined) === afterFiles[rel] (null) is false, so it
+  // IS tracked; recordedAfter is null/falsy, hadAfter true with falsy hash
+  // means we hit the else branch: currentHash should be null (file does not
+  // exist) -> not drifted; hadBefore false -> safeForRemoval; but the file
+  // isn't there, so removal becomes a no-op.
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.removed, [], "no actual removal happened because the file was already gone");
+  assert.deepEqual(result.restored, []);
+});
+
+
+// -- restoreRunFromDir: git-fallback path ----------------------------------
+//
+// When a tracked file existed in `before` but no local backup is on disk,
+// restoreRunFromDir delegates to `git restore --source=HEAD --worktree
+// --staged -- <files>`. The caller passes `resolveGit` and
+// `hasGitRepository` callbacks; the helper refuses if either is missing.
+
+test("git fallback refuses when resolveGit returns null", (t) => {
+  const { root, runDir } = makeWorld();
+  t.after(() => cleanup(root));
+  const original = Buffer.from("v0\n");
+  const runWrote = Buffer.from("v1\n");
+  // before tracked the file, but we don't put a backup in before-files,
+  // so the helper falls through to the git fallback path.
+  writeFile(root, "src/code.js", runWrote);
+  recordStates(
+    runDir,
+    { "src/code.js": sha256(original) },
+    { "src/code.js": sha256(runWrote) },
+  );
+
+  const result = restoreRunFromDir(runDir, root, {
+    resolveGit: () => null,
+    hasGitRepository: () => false,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /backup snapshot|git repository/);
+  // File must NOT have been touched.
+  assert.equal(fs.readFileSync(path.join(root, "src/code.js"), "utf8"), "v1\n");
+});
+
+test("git fallback refuses when hasGitRepository returns false even if git resolves", (t) => {
+  const { root, runDir } = makeWorld();
+  t.after(() => cleanup(root));
+  const original = Buffer.from("v0\n");
+  const runWrote = Buffer.from("v1\n");
+  writeFile(root, "src/code.js", runWrote);
+  recordStates(
+    runDir,
+    { "src/code.js": sha256(original) },
+    { "src/code.js": sha256(runWrote) },
+  );
+
+  const result = restoreRunFromDir(runDir, root, {
+    resolveGit: () => "/usr/bin/git", // fake but non-empty
+    hasGitRepository: () => false,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /backup snapshot|git repository/);
+});
+
+test("git fallback succeeds end-to-end against a real git repo", (t) => {
+  const { root, runDir } = makeWorld();
+  t.after(() => cleanup(root));
+
+  // Initialize a real git repo at root and commit the original file.
+  function git(...args) {
+    const result = cp.spawnSync("git", args, { cwd: root, encoding: "utf8" });
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+    }
+    return result;
+  }
+  git("init", "-q");
+  git("config", "user.email", "test@example.test");
+  git("config", "user.name", "Test");
+  // Disable autocrlf so the round-trip preserves bytes verbatim across
+  // platforms (Windows defaults to autocrlf=true, which would mangle our
+  // exact-bytes assertion below).
+  git("config", "core.autocrlf", "false");
+  const original = Buffer.from("v0 committed\n");
+  writeFile(root, "src/code.js", original);
+  git("add", "src/code.js");
+  git("commit", "-q", "-m", "initial");
+
+  // Simulate the run editing the file (no local backup snapshot is captured).
+  const runWrote = Buffer.from("v1 from run\n");
+  fs.writeFileSync(path.join(root, "src/code.js"), runWrote);
+  recordStates(
+    runDir,
+    { "src/code.js": sha256(original) },
+    { "src/code.js": sha256(runWrote) },
+  );
+  // Note: do NOT create a before-files backup for this rel, so we exercise
+  // the git-fallback branch.
+
+  const result = restoreRunFromDir(runDir, root, {
+    resolveGit: () => "git",
+    hasGitRepository: () => true,
+  });
+
+  assert.equal(result.ok, true, `expected ok=true: ${JSON.stringify(result)}`);
+  assert.ok(result.restored.includes("src/code.js"), "should report the git-fallback file as restored");
+  assert.equal(
+    fs.readFileSync(path.join(root, "src/code.js"), "utf8"),
+    "v0 committed\n",
+    "git restore must put the committed contents back",
+  );
+});
+
+test("git fallback surfaces the git stderr when the git command fails", (t) => {
+  const { root, runDir } = makeWorld();
+  t.after(() => cleanup(root));
+  const original = Buffer.from("v0\n");
+  const runWrote = Buffer.from("v1\n");
+  writeFile(root, "src/code.js", runWrote);
+  recordStates(
+    runDir,
+    { "src/code.js": sha256(original) },
+    { "src/code.js": sha256(runWrote) },
+  );
+
+  // Real `git` resolves and we claim the dir is a repo, but the dir is NOT
+  // a git repo, so `git restore` fails. The helper must surface a friendly
+  // error rather than crash.
+  const result = restoreRunFromDir(runDir, root, {
+    resolveGit: () => "git",
+    hasGitRepository: () => true,
+  });
+  assert.equal(result.ok, false);
+  assert.ok(result.error && result.error.length > 0, "should report some error text");
+  assert.equal(
+    fs.readFileSync(path.join(root, "src/code.js"), "utf8"),
+    "v1\n",
+    "workspace must remain unchanged when undo fails",
+  );
+});

--- a/desktop/test/fs-safety/snapshot-cap.test.js
+++ b/desktop/test/fs-safety/snapshot-cap.test.js
@@ -1,0 +1,30 @@
+// Skipped placeholder tests for the 2 MB snapshot/backup file-size cap.
+//
+// The cap is introduced by PRs targeting issues #4 and #4b ("Every run
+// snapshots and copies the whole repo"). Those PRs are not part of the
+// PR #21 stack this branch is built on, so the snapshot helpers that
+// implement the cap are not present yet. These tests are pre-written as
+// `test.skip` placeholders to lock in the contract once those PRs merge:
+//
+//   - Files larger than 2 MB are not enumerated by snapshot_files().
+//   - The skipped-file manifest records the rel path + size.
+//   - Backup with the cap also skips the same files; the undo path then
+//     falls through to the git-restore fallback (already covered for the
+//     single-file case in restore-run-extras.test.js).
+//
+// TODO(#4, #4b): un-skip these once `desktop/src/main.js`'s snapshot
+// helpers (or their extracted module) gain the cap + manifest behavior on
+// origin/main, and replace the helper imports below with the real ones.
+
+"use strict";
+
+const test = require("node:test");
+
+
+test.skip("snapshot_files skips files over the 2 MB cap (#4 / #4b)");
+
+test.skip("snapshot_files records skipped large files in a manifest with rel path and size (#4 / #4b)");
+
+test.skip("backupBeforeFiles skips files over the 2 MB cap (#4 / #4b)");
+
+test.skip("undo of a run that skipped a >2 MB file falls back to git restore for that file (#4 / #4b)");

--- a/desktop/test/fs-safety/snapshot-gitignore.test.js
+++ b/desktop/test/fs-safety/snapshot-gitignore.test.js
@@ -1,0 +1,31 @@
+// Skipped placeholder tests for gitignore-aware snapshot enumeration.
+//
+// When the project is a git repository, snapshot_files() should skip files
+// excluded by `.gitignore` (in addition to the hard-coded ignored paths
+// already covered by `isSnapshotIgnored`). This behavior is part of the
+// snapshot-perf rework on issue #4 / #4b, which is not in the PR #21 stack
+// this branch is built on. Pre-written placeholders below lock in the
+// contract for un-skipping once those PRs land.
+//
+// TODO(#4, #4b): un-skip once `snapshot_files` consults `.gitignore` (or
+// `git ls-files --others --exclude-standard --cached`) for git projects,
+// then assert:
+//
+//   1. node_modules/ entries listed in .gitignore are NOT in the snapshot.
+//   2. dist/ build output listed in .gitignore is NOT in the snapshot.
+//   3. A file NOT in .gitignore IS in the snapshot.
+//   4. Non-git projects fall back to the existing static ignore set
+//      (already covered by main-process tests for `isSnapshotIgnored`).
+
+"use strict";
+
+const test = require("node:test");
+
+
+test.skip("snapshot_files excludes node_modules entries listed in .gitignore (#4 / #4b)");
+
+test.skip("snapshot_files excludes dist/ build output listed in .gitignore (#4 / #4b)");
+
+test.skip("snapshot_files includes files NOT excluded by .gitignore (#4 / #4b)");
+
+test.skip("snapshot_files keeps the static ignore behavior for non-git projects (#4 / #4b)");


### PR DESCRIPTION
**Stacked on PR #21. Merge #21 first; this PR will auto-retarget to main once #21 lands.**

## Summary

Adds 12 active tests + 8 skipped placeholders under `desktop/test/fs-safety/`, complementing the home-rolled `desktop/test/restore-run.test.js` already shipped in PR #21.

Closes #12.

## What is tested (active, on this stack)

`desktop/test/fs-safety/restore-run-extras.test.js` (run via `node:test` with `--test-concurrency=1`):

- **`fileHashOrNull`** — null for missing paths, null for directories, sha256 hex for regular files.
- **`restoreRunFromDir` input validation** — run-not-found error for a missing dir; legacy guard refuses runs without an after-state file map; same guard rejects runs whose `after-state.files` is not an object. Workspace bytes left untouched in both refusal paths.
- **No-op cases** — identical before/after hashes return empty success without writing anything; a run-removed file recorded as `null` in `after-state` that is already gone from the workspace is a clean no-op.
- **Git-fallback path** (the `safeForGitFallback` branch in `restoreRunFromDir`):
  - Refuses when `resolveGit` returns null.
  - Refuses when `hasGitRepository` returns false even if git resolves.
  - Succeeds end-to-end against a real `git init` repo: makes a commit with the original bytes, simulates the run editing the file (no local backup snapshot), invokes `restoreRunFromDir`, and asserts the committed bytes are restored.
  - Surfaces git's error message when `git restore` fails on a non-repo, while keeping the workspace bytes unchanged.

## What is skipped (placeholders for downstream PRs)

These are pre-written `test.skip` placeholders that document the contract for behavior that depends on PRs not yet in this stack. Per the team's convention, they will be un-skipped after the relevant PRs land.

- `desktop/test/fs-safety/snapshot-cap.test.js` — 4 placeholders for the 2 MB snapshot/backup file-size cap from issues #4 / #4b (skipped files, skipped-file manifest, backup parity, undo fallback to git restore).
- `desktop/test/fs-safety/snapshot-gitignore.test.js` — 4 placeholders for gitignore-aware snapshot enumeration on git projects from issues #4 / #4b (excludes `node_modules`/`dist`, includes non-ignored files, keeps static-ignore behavior for non-git projects).

## Why stacked on `fix/1-undo-drift-detection`

`desktop/src/restore-run.js` and the `after-state.json` hash-map contract are introduced by PR #21 and are not on `origin/main` yet. These tests target that module directly, so they only make sense once PR #21 (or its successor) merges. Same stacking pattern that was used for the electron-lane shared-budget-defaults work.

## Test plan

- [ ] `cd desktop && npm install` (one-time, dev only)
- [ ] `cd desktop && npm run check` — Node syntax check (no production source changed)
- [ ] `cd desktop && npm run smoke` — PR #21's inline restore-run tests still pass via the smoke runner
- [ ] `cd desktop && npm run test:fs-safety` — 12 passed, 8 skipped in ~0.7s
- [ ] After PR #21 merges: GitHub auto-retargets this PR to `main`. Re-run the three commands above on the rebased state.
- [ ] After PRs for issues #4 / #4b land: open a follow-up that un-skips the snapshot-cap and snapshot-gitignore placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)