### PR TITLE
Extract desktop/src/settings-store.js (#17 Stage 4a)

### DIFF
--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -7,6 +7,16 @@ const snapshot = require("./snapshot");
 const policy = require("./policy");
 const { spawnAsync } = require("./spawn-async");
 const { restoreRunFromDir } = require("./restore-run");
+const settingsStore = require("./settings-store");
+const {
+  ensureDir,
+  readJson,
+  writeJson,
+  readText,
+  backupFileOncePerMinute,
+  nonEmptyChatSessions,
+  sanitizedSettings,
+} = settingsStore;
 
 const APP_ROOT = path.resolve(__dirname, "..", "..");
 const APP_AI_DIR = path.join(APP_ROOT, ".ai");
@@ -126,10 +136,6 @@ function createWindow() {
   mainWindow.loadFile(path.join(__dirname, "renderer", "index.html"));
 }
 
-function ensureDir(dir) {
-  fs.mkdirSync(dir, { recursive: true });
-}
-
 function ensureWorkspace(root = projectRoot()) {
   const aiDir = path.join(root, ".ai");
   ensureDir(aiDir);
@@ -158,41 +164,6 @@ function ensureGlobalMemory() {
   return dir;
 }
 
-function readJson(file, fallback) {
-  try {
-    return JSON.parse(fs.readFileSync(file, "utf8"));
-  } catch {
-    return fallback;
-  }
-}
-
-function writeJson(file, value) {
-  ensureDir(path.dirname(file));
-  fs.writeFileSync(file, JSON.stringify(value, null, 2) + "\n", "utf8");
-}
-
-function backupFileOncePerMinute(file, label) {
-  if (!fs.existsSync(file)) return;
-  const now = new Date();
-  const stamp = [
-    now.getFullYear(),
-    String(now.getMonth() + 1).padStart(2, "0"),
-    String(now.getDate()).padStart(2, "0"),
-    String(now.getHours()).padStart(2, "0"),
-    String(now.getMinutes()).padStart(2, "0"),
-  ].join("");
-  const backup = path.join(path.dirname(file), `${path.basename(file, ".json")}.${label}-${stamp}.json`);
-  if (!fs.existsSync(backup)) {
-    fs.copyFileSync(file, backup);
-  }
-}
-
-function nonEmptyChatSessions(value) {
-  const sessions = value?.chatSessions;
-  if (!sessions || typeof sessions !== "object") return false;
-  return Object.values(sessions).some((items) => Array.isArray(items) && items.length);
-}
-
 function secretsFile() {
   return path.join(app.getPath("userData"), "secrets.json");
 }
@@ -200,14 +171,6 @@ function secretsFile() {
 function authSecrets() {
   const secrets = readJson(secretsFile(), {});
   return secrets && typeof secrets === "object" ? secrets : {};
-}
-
-function sanitizedSettings(value) {
-  const next = { ...(value || {}) };
-  next.auth = { ...(next.auth || {}) };
-  delete next.auth.openaiApiKey;
-  delete next.auth.anthropicApiKey;
-  return next;
 }
 
 function persistAuthSecrets(value) {
@@ -222,14 +185,6 @@ function persistAuthSecrets(value) {
   }
   writeJson(secretsFile(), next);
   return next;
-}
-
-function readText(file) {
-  try {
-    return fs.readFileSync(file, "utf8");
-  } catch {
-    return "";
-  }
 }
 
 function settings() {

--- a/desktop/src/settings-store.js
+++ b/desktop/src/settings-store.js
@@ -1,0 +1,69 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function readJson(file, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(file, value) {
+  ensureDir(path.dirname(file));
+  fs.writeFileSync(file, JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function readText(file) {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function backupFileOncePerMinute(file, label) {
+  if (!fs.existsSync(file)) return;
+  const now = new Date();
+  const stamp = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+  ].join("");
+  const backup = path.join(path.dirname(file), `${path.basename(file, ".json")}.${label}-${stamp}.json`);
+  if (!fs.existsSync(backup)) {
+    fs.copyFileSync(file, backup);
+  }
+}
+
+function nonEmptyChatSessions(value) {
+  const sessions = value?.chatSessions;
+  if (!sessions || typeof sessions !== "object") return false;
+  return Object.values(sessions).some((items) => Array.isArray(items) && items.length);
+}
+
+function sanitizedSettings(value) {
+  const next = { ...(value || {}) };
+  next.auth = { ...(next.auth || {}) };
+  delete next.auth.openaiApiKey;
+  delete next.auth.anthropicApiKey;
+  return next;
+}
+
+module.exports = {
+  ensureDir,
+  readJson,
+  writeJson,
+  readText,
+  backupFileOncePerMinute,
+  nonEmptyChatSessions,
+  sanitizedSettings,
+};

--- a/desktop/test/smoke.js
+++ b/desktop/test/smoke.js
@@ -81,7 +81,7 @@ for (const channel of REQUIRED_IPC_HANDLERS) {
 assert.match(mainJs, /AIDEV_GLOBAL_RULES_DIR/, "global user memory should be passed to subprocesses");
 assert.match(mainJs, /AIDEV_PROJECT_ROOT/, "project root should be passed explicitly to subprocesses");
 assert.match(mainJs, /function secretsFile\(/, "auth secrets should be stored outside project settings");
-assert.match(mainJs, /delete next\.auth\.openaiApiKey/, "OpenAI key must not be persisted in project settings");
+assert.match(read("src/settings-store.js"), /delete next\.auth\.openaiApiKey/, "OpenAI key must not be persisted in project settings (now in settings-store.js)");
 assert.match(mainJs, /backupFileOncePerMinute/, "settings saves should create safety backups");
 assert.match(mainJs, /nonEmptyChatSessions/, "settings saves should preserve existing chat history");
 assert.match(mainJs, /detached \? "read-only"/, "standalone chats should run in read-only sandbox");


### PR DESCRIPTION
## Summary
First slice of issue #17 Stage 4. Carves the pure file-IO and settings-shape helpers out of `desktop/src/main.js` into a focused module.

## What moved
`ensureDir`, `readJson`, `writeJson`, `readText`, `backupFileOncePerMinute`, `nonEmptyChatSessions`, `sanitizedSettings` → `desktop/src/settings-store.js`.

`main.js` destructure-imports them, so every existing call site (including `settings()`, `persistAuthSecrets`, `runValidation`, `buildProjectIndex`, etc.) keeps working unchanged. One smoke regex for `delete next.auth.openaiApiKey` now reads `settings-store.js` since the sanitizer moved with the helper.

## Why a partial Stage 4
The original plan was a four-module split (projects + settings-store + runs + ipc, ~1500 LoC). I'm shipping the cleanest seam first — pure utility helpers with no electron-app coupling — so it's reviewable in isolation. The remaining project-management, run-lifecycle, and IPC-wiring extracts can each land as their own focused PR.

## Numbers
- `main.js`: 1888 → 1843 (-45)
- `settings-store.js`: 69 lines (new)

## Test plan
- [x] `npm run check` — clean
- [x] `npm run smoke` — 71 unit tests + 12 behavior smoke tests pass

Refs #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)