### PR TITLE
Extract desktop/src/projects.js (#17 Stage 4b)

### DIFF
--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -17,6 +17,7 @@ const {
   nonEmptyChatSessions,
   sanitizedSettings,
 } = settingsStore;
+const { createProjectPaths } = require("./projects");
 
 const APP_ROOT = path.resolve(__dirname, "..", "..");
 const APP_AI_DIR = path.join(APP_ROOT, ".ai");
@@ -310,38 +311,20 @@ function touchProject(root, extra = {}) {
   return current;
 }
 
-function projectRoot() {
-  const root = settings().projectRoot || APP_ROOT;
-  return path.resolve(root);
-}
-
-function projectAiDir() {
-  return path.join(projectRoot(), ".ai");
-}
-
-function projectRunsDir() {
-  return path.join(projectAiDir(), "runs");
-}
-
-function projectDesktopDir() {
-  return path.join(projectAiDir(), "desktop");
-}
-
-function aidevScript() {
-  return path.join(APP_ROOT, "aidev.py");
-}
+const _projectPaths = createProjectPaths({ getSettings: settings, appRoot: APP_ROOT });
+const {
+  projectRoot,
+  projectAiDir,
+  projectRunsDir,
+  projectDesktopDir,
+  projectIndexFile,
+  terminalHistoryFile,
+  aidevScript,
+} = _projectPaths;
 
 function projectConfig() {
   ensureWorkspace();
   return readJson(path.join(projectAiDir(), "config", "project.json"), {});
-}
-
-function projectIndexFile() {
-  return path.join(projectAiDir(), "project", "index.json");
-}
-
-function terminalHistoryFile() {
-  return path.join(projectDesktopDir(), "terminal-history.json");
 }
 
 function sourceKind(rel) {

--- a/desktop/src/projects.js
+++ b/desktop/src/projects.js
@@ -1,0 +1,45 @@
+"use strict";
+
+const path = require("path");
+
+function createProjectPaths({ getSettings, appRoot }) {
+  function projectRoot() {
+    return path.resolve(getSettings().projectRoot || appRoot);
+  }
+
+  function projectAiDir() {
+    return path.join(projectRoot(), ".ai");
+  }
+
+  function projectRunsDir() {
+    return path.join(projectAiDir(), "runs");
+  }
+
+  function projectDesktopDir() {
+    return path.join(projectAiDir(), "desktop");
+  }
+
+  function projectIndexFile() {
+    return path.join(projectAiDir(), "project", "index.json");
+  }
+
+  function terminalHistoryFile() {
+    return path.join(projectDesktopDir(), "terminal-history.json");
+  }
+
+  function aidevScript() {
+    return path.join(appRoot, "aidev.py");
+  }
+
+  return {
+    projectRoot,
+    projectAiDir,
+    projectRunsDir,
+    projectDesktopDir,
+    projectIndexFile,
+    terminalHistoryFile,
+    aidevScript,
+  };
+}
+
+module.exports = { createProjectPaths };


### PR DESCRIPTION
## Summary
Second slice of issue #17 Stage 4. Carves the pure path computations that name-scope a project out of `desktop/src/main.js` into a focused module.

## What moved
`projectRoot`, `projectAiDir`, `projectRunsDir`, `projectDesktopDir`, `projectIndexFile`, `terminalHistoryFile`, `aidevScript` → `desktop/src/projects.js`.

`projects.js` exports a `createProjectPaths({ getSettings, appRoot })` factory; `main.js` wires it to its own `settings()` and `APP_ROOT`, destructures the bound functions, and keeps every call site working unchanged.

## Why a factory
These functions all close over `settings()` (for `projectRoot`) and `APP_ROOT` (for `aidevScript`). Passing those in once at construction keeps `projects.js` free of any electron-app coupling and trivially unit-testable.

## What didn't move yet
`projectConfig` stays in `main.js` because it still calls `ensureWorkspace`, which depends on `APP_DESKTOP_DATA_DIR` setup that isn't extracted yet. That's a future slice.

## Numbers
- `main.js`: 1843 → 1826 (-17 in this PR; -62 cumulative since Stage 4a)
- `projects.js`: 45 lines (new)

## Test plan
- [x] `npm run check` — clean
- [x] `npm run smoke` — 71 unit tests + 12 behavior smoke tests pass

Refs #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)